### PR TITLE
Added EJ RANGE 24 paper type and fixed a bug

### DIFF
--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -88,13 +88,14 @@ AVERY_L7157 = PaperConfig(
     vertical_stride=24.3 * mm,
 )
 
+
 EJ_RANGE_24 = PaperConfig(
     pagesize=A4,
     sticker_width=63.5 * mm,
     sticker_height=33.9 * mm,
     sticker_corner_radius=2 * mm,
     left_margin=6.5 * mm,
-    top_margin=13.2* mm,
+    top_margin=13.2 * mm,
     horizontal_stride=66.45 * mm,
     vertical_stride=33.9 * mm,
 )
@@ -477,12 +478,15 @@ def main():
     layout = AVERY_5260
     # layout = AVERY_L7157
     # layout = EJ_RANGE_24
+
     # ############################################################################
     # Put your own resistor values in here!
+    #
     # This has to be a grid of:
-    # 10*3 values for Avery 5260 
-    # 11*3 for Avery L7157.
-    # 8*3 for EJ Range 24
+    #  - 10*3 values for Avery 5260
+    #  - 11*3 for Avery L7157.
+    #  - 8*3 for EJ Range 24
+    #
     # Add "None" if no label should get generated at a specific position.
     # ############################################################################
     resistor_values = [

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -104,7 +104,9 @@ EJ_RANGE_24 = PaperConfig(
 class StickerRect:
     def __init__(self, layout: PaperConfig, row: int, column: int):
         self.left = layout.left_margin + layout.horizontal_stride * column
-        self.bottom = layout.pagesize[1] - (layout.sticker_height + layout.top_margin + layout.vertical_stride * row)
+        self.bottom = layout.pagesize[1] - (
+            layout.sticker_height + layout.top_margin + layout.vertical_stride * row
+        )
         self.width = layout.sticker_width
         self.height = layout.sticker_height
         self.corner = layout.sticker_corner_radius

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -88,11 +88,22 @@ AVERY_L7157 = PaperConfig(
     vertical_stride=24.3 * mm,
 )
 
+EJ_RANGE_24 = PaperConfig(
+    pagesize=A4,
+    sticker_width=63.5 * mm,
+    sticker_height=33.9 * mm,
+    sticker_corner_radius=2 * mm,
+    left_margin=6.5 * mm,
+    top_margin=13.2* mm,
+    horizontal_stride=66.45 * mm,
+    vertical_stride=33.9 * mm,
+)
+
 
 class StickerRect:
     def __init__(self, layout: PaperConfig, row: int, column: int):
         self.left = layout.left_margin + layout.horizontal_stride * column
-        self.bottom = layout.pagesize[1] - (layout.top_margin + layout.vertical_stride * row)
+        self.bottom = layout.pagesize[1] - (layout.top_margin + layout.vertical_stride * (row+1))
         self.width = layout.sticker_width
         self.height = layout.sticker_height
         self.corner = layout.sticker_corner_radius
@@ -465,10 +476,13 @@ def main():
     # ############################################################################
     layout = AVERY_5260
     # layout = AVERY_L7157
-
+    # layout = EJ_RANGE_24
     # ############################################################################
     # Put your own resistor values in here!
-    # This has to be a grid of 10*3 values for Avery 5260 or 11*3 for Avery L7157.
+    # This has to be a grid of:
+    # 10*3 values for Avery 5260 
+    # 11*3 for Avery L7157.
+    # 8*3 for EJ Range 24
     # Add "None" if no label should get generated at a specific position.
     # ############################################################################
     resistor_values = [


### PR DESCRIPTION
Great tool, many thanks for putting it together!

I am using these labels I bought on amazon and wanted to add a layout for it:
https://www.amazon.co.uk/gp/product/B07N5VBBPC

After creating a layout with the appropriate measurements I could see that the top row was above the edge of the canvas. Looking at the code, it became clear there is a layout issue here. When creating StickerRect, the bottom coord is calculated from the row number. As this is zero-indexed, this number is 0 for the top row, putting the BOTTOM of the top row at the margin point. This is where the TOP of the top row should be. Simply adding 1 to the index resolves this.

I am unclear how the existing layouts for your paper types print correctly (I don't have the measurements to check them). I suspect the top margin value has been enlarged to make them work? Anyway, it is confusing that the top-margin layout entry currently controls where the BOTTOM of the top row should go. This makes it more difficult for others who wish to add their own paper types.