### PR TITLE
Add dockerfile

### DIFF
--- a/Docker-compose.yaml
+++ b/Docker-compose.yaml
@@ -4,4 +4,4 @@ services:
     build: .
     volumes:
       - .:/resistorLabels
-    entrypoint: python3 /resistorLabels/LabelGenerator.py --roboto
+    entrypoint: python3 /resistorLabels/LabelGenerator.py

--- a/Docker-compose.yaml
+++ b/Docker-compose.yaml
@@ -1,0 +1,7 @@
+services:
+  labelgenerator:
+    image: labelgenerator
+    build: .
+    volumes:
+      - .:/resistorLabels
+    entrypoint: python3 /resistorLabels/LabelGenerator.py --roboto

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.7-slim
+WORKDIR /resistorLabels
+COPY requirements.txt /resistorLabels
+COPY Roboto-Bold.ttf /resistorLabels
+
+RUN apt update && apt install -y libpq-dev gcc
+RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ COPY requirements.txt /resistorLabels
 COPY Roboto-Bold.ttf /resistorLabels
 RUN echo 'deb http://deb.debian.org/debian bullseye contrib' >> /etc/apt/sources.list
 
-RUN apt update && apt install -y libpq-dev gcc ttf-mscorefonts-installer
+RUN apt update && apt install -y gcc ttf-mscorefonts-installer
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM python:3.7-slim
+FROM python:3.7-slim-bullseye
 WORKDIR /resistorLabels
 COPY requirements.txt /resistorLabels
 COPY Roboto-Bold.ttf /resistorLabels
+RUN echo 'deb http://deb.debian.org/debian bullseye contrib' >> /etc/apt/sources.list
 
-RUN apt update && apt install -y libpq-dev gcc
+RUN apt update && apt install -y libpq-dev gcc ttf-mscorefonts-installer
 RUN pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -13,12 +13,6 @@ The generated labels include:
 
 <img src="Example.svg">
 
-# Usage (Docker)
-
-If you have docker and docker compose installed, run the following command (Otherwise see python steps below)
-
-- `docker compose run labelgenerator`
-
 # Usage (python)
 
 -   Install python3
@@ -28,6 +22,12 @@ If you have docker and docker compose installed, run the following command (Othe
 -   Run the script `LabelGenerator.py`!
 
 It will now generate a `ResistorLabels.pdf` that can be used to print onto AVERY 5260/L7157.
+
+# Usage (Docker)
+
+If you have docker and docker compose installed, run the following command.
+
+- `docker compose run labelgenerator`
 
 # More Details
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,16 @@ The generated labels include:
 
 <img src="Example.svg">
 
-# Usage
+# Usage (Docker)
+
+If you have docker and docker compose installed, you can easily generate the pdf by running the following commands: (Otherwise see python steps below)
+
+```
+docker compose build labelgenerator
+docker compose run labelgenerator
+```
+
+# Usage (python)
 
 -   Install python3
 -   Install the python3 library `reportlab`. This library is used to do the actual PDF generation.

--- a/README.md
+++ b/README.md
@@ -15,12 +15,9 @@ The generated labels include:
 
 # Usage (Docker)
 
-If you have docker and docker compose installed, you can easily generate the pdf by running the following commands: (Otherwise see python steps below)
+If you have docker and docker compose installed, run the following command (Otherwise see python steps below)
 
-```
-docker compose build labelgenerator
-docker compose run labelgenerator
-```
+- `docker compose run labelgenerator`
 
 # Usage (python)
 


### PR DESCRIPTION
I often struggle to get python working correctly on my Mac. 

```
python --version
zsh: command not found: python

python3 --version
/opt/homebrew/bin/python3: can't open file 
```

This PR adds a Dockerfile which should make this code more portable for those with broken pythons (or python not installed at all). 

If a user has docker/docker-compose installed they can get your script working with just 1 command 

```
docker compose run labelgenerator
```

Note: I chose to install `ttf-mscorefonts-installer` and not mention --roboto based on comments you made in another issue. 

If a user wants to use roboto they can modify the entrypoint in `docker-compse.yaml`

```
    entrypoint: python3 /resistorLabels/LabelGenerator.py --roboto
    