### PR TITLE
Allow zero ohm resistor

### DIFF
--- a/Example.pdf
+++ b/Example.pdf
@@ -2,7 +2,7 @@
 %ìåãû ReportLab Generated PDF document http://www.reportlab.com
 1 0 obj
 <<
-/F1 2 0 R /F2+0 60 0 R
+/F1 2 0 R /F2+0 62 0 R
 >>
 endobj
 2 0 obj
@@ -12,279 +12,289 @@ endobj
 endobj
 3 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 130.725 721.4 130.725 703.4 ] /Extend [true true] /Function 63 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 130.725 721.4 130.725 703.4 ] /Extend [true true] /Function 65 0 R /ShadingType 2
 >>
 endobj
 4 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 130.725 649.4 130.725 631.4 ] /Extend [true true] /Function 64 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 176.175 721.4 176.175 703.4 ] /Extend [true true] /Function 66 0 R /ShadingType 2
 >>
 endobj
 5 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 176.175 649.4 176.175 631.4 ] /Extend [true true] /Function 65 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 526.725 721.4 526.725 703.4 ] /Extend [true true] /Function 67 0 R /ShadingType 2
 >>
 endobj
 6 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 328.725 649.4 328.725 631.4 ] /Extend [true true] /Function 66 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 130.725 649.4 130.725 631.4 ] /Extend [true true] /Function 68 0 R /ShadingType 2
 >>
 endobj
 7 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 374.175 649.4 374.175 631.4 ] /Extend [true true] /Function 67 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 176.175 649.4 176.175 631.4 ] /Extend [true true] /Function 69 0 R /ShadingType 2
 >>
 endobj
 8 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 526.725 649.4 526.725 631.4 ] /Extend [true true] /Function 68 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 328.725 649.4 328.725 631.4 ] /Extend [true true] /Function 70 0 R /ShadingType 2
 >>
 endobj
 9 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 572.175 649.4 572.175 631.4 ] /Extend [true true] /Function 69 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 374.175 649.4 374.175 631.4 ] /Extend [true true] /Function 71 0 R /ShadingType 2
 >>
 endobj
 10 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 130.725 577.4 130.725 559.4 ] /Extend [true true] /Function 70 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 526.725 649.4 526.725 631.4 ] /Extend [true true] /Function 72 0 R /ShadingType 2
 >>
 endobj
 11 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 176.175 577.4 176.175 559.4 ] /Extend [true true] /Function 71 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 572.175 649.4 572.175 631.4 ] /Extend [true true] /Function 73 0 R /ShadingType 2
 >>
 endobj
 12 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 328.725 577.4 328.725 559.4 ] /Extend [true true] /Function 72 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 130.725 577.4 130.725 559.4 ] /Extend [true true] /Function 74 0 R /ShadingType 2
 >>
 endobj
 13 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 374.175 577.4 374.175 559.4 ] /Extend [true true] /Function 73 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 176.175 577.4 176.175 559.4 ] /Extend [true true] /Function 75 0 R /ShadingType 2
 >>
 endobj
 14 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 526.725 577.4 526.725 559.4 ] /Extend [true true] /Function 74 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 328.725 577.4 328.725 559.4 ] /Extend [true true] /Function 76 0 R /ShadingType 2
 >>
 endobj
 15 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 572.175 577.4 572.175 559.4 ] /Extend [true true] /Function 75 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 374.175 577.4 374.175 559.4 ] /Extend [true true] /Function 77 0 R /ShadingType 2
 >>
 endobj
 16 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 130.725 505.4 130.725 487.4 ] /Extend [true true] /Function 76 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 526.725 577.4 526.725 559.4 ] /Extend [true true] /Function 78 0 R /ShadingType 2
 >>
 endobj
 17 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 176.175 505.4 176.175 487.4 ] /Extend [true true] /Function 77 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 572.175 577.4 572.175 559.4 ] /Extend [true true] /Function 79 0 R /ShadingType 2
 >>
 endobj
 18 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 328.725 505.4 328.725 487.4 ] /Extend [true true] /Function 78 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 130.725 505.4 130.725 487.4 ] /Extend [true true] /Function 80 0 R /ShadingType 2
 >>
 endobj
 19 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 374.175 505.4 374.175 487.4 ] /Extend [true true] /Function 79 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 176.175 505.4 176.175 487.4 ] /Extend [true true] /Function 81 0 R /ShadingType 2
 >>
 endobj
 20 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 526.725 505.4 526.725 487.4 ] /Extend [true true] /Function 80 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 328.725 505.4 328.725 487.4 ] /Extend [true true] /Function 82 0 R /ShadingType 2
 >>
 endobj
 21 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 572.175 505.4 572.175 487.4 ] /Extend [true true] /Function 81 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 374.175 505.4 374.175 487.4 ] /Extend [true true] /Function 83 0 R /ShadingType 2
 >>
 endobj
 22 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 130.725 433.4 130.725 415.4 ] /Extend [true true] /Function 82 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 526.725 505.4 526.725 487.4 ] /Extend [true true] /Function 84 0 R /ShadingType 2
 >>
 endobj
 23 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 176.175 433.4 176.175 415.4 ] /Extend [true true] /Function 83 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 572.175 505.4 572.175 487.4 ] /Extend [true true] /Function 85 0 R /ShadingType 2
 >>
 endobj
 24 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 328.725 433.4 328.725 415.4 ] /Extend [true true] /Function 84 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 130.725 433.4 130.725 415.4 ] /Extend [true true] /Function 86 0 R /ShadingType 2
 >>
 endobj
 25 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 374.175 433.4 374.175 415.4 ] /Extend [true true] /Function 85 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 176.175 433.4 176.175 415.4 ] /Extend [true true] /Function 87 0 R /ShadingType 2
 >>
 endobj
 26 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 526.725 433.4 526.725 415.4 ] /Extend [true true] /Function 86 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 328.725 433.4 328.725 415.4 ] /Extend [true true] /Function 88 0 R /ShadingType 2
 >>
 endobj
 27 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 572.175 433.4 572.175 415.4 ] /Extend [true true] /Function 87 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 374.175 433.4 374.175 415.4 ] /Extend [true true] /Function 89 0 R /ShadingType 2
 >>
 endobj
 28 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 130.725 361.4 130.725 343.4 ] /Extend [true true] /Function 88 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 526.725 433.4 526.725 415.4 ] /Extend [true true] /Function 90 0 R /ShadingType 2
 >>
 endobj
 29 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 176.175 361.4 176.175 343.4 ] /Extend [true true] /Function 89 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 572.175 433.4 572.175 415.4 ] /Extend [true true] /Function 91 0 R /ShadingType 2
 >>
 endobj
 30 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 526.725 361.4 526.725 343.4 ] /Extend [true true] /Function 90 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 130.725 361.4 130.725 343.4 ] /Extend [true true] /Function 92 0 R /ShadingType 2
 >>
 endobj
 31 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 572.175 361.4 572.175 343.4 ] /Extend [true true] /Function 91 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 176.175 361.4 176.175 343.4 ] /Extend [true true] /Function 93 0 R /ShadingType 2
 >>
 endobj
 32 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 130.725 289.4 130.725 271.4 ] /Extend [true true] /Function 92 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 526.725 361.4 526.725 343.4 ] /Extend [true true] /Function 94 0 R /ShadingType 2
 >>
 endobj
 33 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 176.175 289.4 176.175 271.4 ] /Extend [true true] /Function 93 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 572.175 361.4 572.175 343.4 ] /Extend [true true] /Function 95 0 R /ShadingType 2
 >>
 endobj
 34 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 328.725 289.4 328.725 271.4 ] /Extend [true true] /Function 94 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 130.725 289.4 130.725 271.4 ] /Extend [true true] /Function 96 0 R /ShadingType 2
 >>
 endobj
 35 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 374.175 289.4 374.175 271.4 ] /Extend [true true] /Function 95 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 176.175 289.4 176.175 271.4 ] /Extend [true true] /Function 97 0 R /ShadingType 2
 >>
 endobj
 36 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 526.725 289.4 526.725 271.4 ] /Extend [true true] /Function 96 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 328.725 289.4 328.725 271.4 ] /Extend [true true] /Function 98 0 R /ShadingType 2
 >>
 endobj
 37 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 572.175 289.4 572.175 271.4 ] /Extend [true true] /Function 97 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 374.175 289.4 374.175 271.4 ] /Extend [true true] /Function 99 0 R /ShadingType 2
 >>
 endobj
 38 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 130.725 217.4 130.725 199.4 ] /Extend [true true] /Function 98 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 526.725 289.4 526.725 271.4 ] /Extend [true true] /Function 100 0 R /ShadingType 2
 >>
 endobj
 39 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 176.175 217.4 176.175 199.4 ] /Extend [true true] /Function 99 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 572.175 289.4 572.175 271.4 ] /Extend [true true] /Function 101 0 R /ShadingType 2
 >>
 endobj
 40 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 328.725 217.4 328.725 199.4 ] /Extend [true true] /Function 100 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 130.725 217.4 130.725 199.4 ] /Extend [true true] /Function 102 0 R /ShadingType 2
 >>
 endobj
 41 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 374.175 217.4 374.175 199.4 ] /Extend [true true] /Function 101 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 176.175 217.4 176.175 199.4 ] /Extend [true true] /Function 103 0 R /ShadingType 2
 >>
 endobj
 42 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 526.725 217.4 526.725 199.4 ] /Extend [true true] /Function 102 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 328.725 217.4 328.725 199.4 ] /Extend [true true] /Function 104 0 R /ShadingType 2
 >>
 endobj
 43 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 572.175 217.4 572.175 199.4 ] /Extend [true true] /Function 103 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 374.175 217.4 374.175 199.4 ] /Extend [true true] /Function 105 0 R /ShadingType 2
 >>
 endobj
 44 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 130.725 145.4 130.725 127.4 ] /Extend [true true] /Function 104 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 526.725 217.4 526.725 199.4 ] /Extend [true true] /Function 106 0 R /ShadingType 2
 >>
 endobj
 45 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 176.175 145.4 176.175 127.4 ] /Extend [true true] /Function 105 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 572.175 217.4 572.175 199.4 ] /Extend [true true] /Function 107 0 R /ShadingType 2
 >>
 endobj
 46 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 328.725 145.4 328.725 127.4 ] /Extend [true true] /Function 106 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 130.725 145.4 130.725 127.4 ] /Extend [true true] /Function 108 0 R /ShadingType 2
 >>
 endobj
 47 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 374.175 145.4 374.175 127.4 ] /Extend [true true] /Function 107 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 176.175 145.4 176.175 127.4 ] /Extend [true true] /Function 109 0 R /ShadingType 2
 >>
 endobj
 48 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 526.725 145.4 526.725 127.4 ] /Extend [true true] /Function 108 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 328.725 145.4 328.725 127.4 ] /Extend [true true] /Function 110 0 R /ShadingType 2
 >>
 endobj
 49 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 572.175 145.4 572.175 127.4 ] /Extend [true true] /Function 109 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 374.175 145.4 374.175 127.4 ] /Extend [true true] /Function 111 0 R /ShadingType 2
 >>
 endobj
 50 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 130.725 73.4 130.725 55.4 ] /Extend [true true] /Function 110 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 526.725 145.4 526.725 127.4 ] /Extend [true true] /Function 112 0 R /ShadingType 2
 >>
 endobj
 51 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 176.175 73.4 176.175 55.4 ] /Extend [true true] /Function 111 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 572.175 145.4 572.175 127.4 ] /Extend [true true] /Function 113 0 R /ShadingType 2
 >>
 endobj
 52 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 328.725 73.4 328.725 55.4 ] /Extend [true true] /Function 112 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 130.725 73.4 130.725 55.4 ] /Extend [true true] /Function 114 0 R /ShadingType 2
 >>
 endobj
 53 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 374.175 73.4 374.175 55.4 ] /Extend [true true] /Function 113 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 176.175 73.4 176.175 55.4 ] /Extend [true true] /Function 115 0 R /ShadingType 2
 >>
 endobj
 54 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 526.725 73.4 526.725 55.4 ] /Extend [true true] /Function 114 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 328.725 73.4 328.725 55.4 ] /Extend [true true] /Function 116 0 R /ShadingType 2
 >>
 endobj
 55 0 obj
 <<
-/ColorSpace /DeviceRGB /Coords [ 572.175 73.4 572.175 55.4 ] /Extend [true true] /Function 115 0 R /ShadingType 2
+/ColorSpace /DeviceRGB /Coords [ 374.175 73.4 374.175 55.4 ] /Extend [true true] /Function 117 0 R /ShadingType 2
 >>
 endobj
 56 0 obj
 <<
-/Contents 117 0 R /MediaBox [ 0 0 612 792 ] /Parent 116 0 R /Resources <<
+/ColorSpace /DeviceRGB /Coords [ 526.725 73.4 526.725 55.4 ] /Extend [true true] /Function 118 0 R /ShadingType 2
+>>
+endobj
+57 0 obj
+<<
+/ColorSpace /DeviceRGB /Coords [ 572.175 73.4 572.175 55.4 ] /Extend [true true] /Function 119 0 R /ShadingType 2
+>>
+endobj
+58 0 obj
+<<
+/Contents 121 0 R /MediaBox [ 0 0 612 792 ] /Parent 120 0 R /Resources <<
 /ExtGState <<
 /gRLs0 <<
 /CA .25
 >> /gRLs1 <<
-/ca .3
->> /gRLs2 <<
 /CA 1
+>> /gRLs2 <<
+/ca .3
 >> /gRLs3 <<
 /ca 1
 >> /gRLs4 <<
@@ -299,7 +309,8 @@ endobj
   /Sh36 39 0 R /Sh37 40 0 R /Sh38 41 0 R /Sh39 42 0 R /Sh4 7 0 R /Sh40 43 0 R 
   /Sh41 44 0 R /Sh42 45 0 R /Sh43 46 0 R /Sh44 47 0 R /Sh45 48 0 R /Sh46 49 0 R 
   /Sh47 50 0 R /Sh48 51 0 R /Sh49 52 0 R /Sh5 8 0 R /Sh50 53 0 R /Sh51 54 0 R 
-  /Sh52 55 0 R /Sh6 9 0 R /Sh7 10 0 R /Sh8 11 0 R /Sh9 12 0 R
+  /Sh52 55 0 R /Sh53 56 0 R /Sh54 57 0 R /Sh6 9 0 R /Sh7 10 0 R /Sh8 11 0 R 
+  /Sh9 12 0 R
 >>
 >> /Rotate 0 /Trans <<
 
@@ -307,7 +318,7 @@ endobj
   /Type /Page
 >>
 endobj
-57 0 obj
+59 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 717
 >>
@@ -323,7 +334,7 @@ xúu’ÕjaÖÒΩW1ÀñRÙˇm@ÛY§-Mn¿åc*ƒQF≥»›◊„	)îv@yÜô+œ¯ÍÓ˙ÆﬂõÒèa◊>t«fΩÈWCwÿΩm◊<
 ø“Ø+˝
 ø“Ø˝ø—o˝ø—o˝ø—o˝ø—o˝ø—o˝ø—o˝ø—o˝ø—o;˝ø”Ô;˝ø”Ô;˝ø”Ô;˝ø”Ô;˝ø”Ô;˝ø”Ô;˝ø”Ô;˝ø”Ô˝–˝–˝–˝–˝–˝–˝–˝–'˝	“ü'˝	“ü'˝	“ü'˝	“ü'˝	“ü'˝	“ü'˝	“ü'˝	“ü˝—_˝—_˝—_˝—_˝—_˝—_˝—_˝—_O·W¡ˇ∆i-ﬁWªÅÂ˚X§ˆuNcuû«Ûa~6}˜±†˚›ß˘¥ª£\endstream
 endobj
-58 0 obj
+60 0 obj
 <<
 /Filter [ /FlateDecode ] /Length 29827 /Length1 48968
 >>
@@ -428,16 +439,16 @@ n‹$Ù&!†E(Bî"!†EàRÑhÈ‡≈ P ≈ PPä† ä††§æ@1@)∫Ä¢(∫Ä¢ãRtEPtE•Ë
 ªÔÍ;°Ak»!V‘üftÿ@fNˇö4sh51ËS´r“we>Õ!|È<˝1}ﬁöòI*ıñzI¥3ídÑhìíîækUNÊ”¯òídÜhKﬁöπÉÂA"G‰∂≈rzÆÍ#¶ì|ó◊YÑ¸hr:j
 4¬?Ñ£‘¡ﬂBLπÏ/zπﬂƒƒDÑ\&<Ñ⁄b≈=m±Â‰¿^ûá¢˚!Æ,«≤4ÓÑV€43{=P	%≈»É…]$V]<3•û‚≤TàN;≤+Éœ¡æ¨„ò…x9]>3ì”πd˝ù._&˚∞\%~‹ëSIC™R‚»æd)‡@¡Å“5SS•S5‰ÿ¬'èB§Û(J„ÂGYıDíÇ 0⁄è‰ÔÃ@y≈≥≤i¡Sx˙=z ∫T‘Â–3˙ú`#JÆö}4©9>¢döêKüHíM(D4qÇ…ô»°πÀ¸/:A≤"ÚÑ^˙ﬂÖ˘*$endstream
 endobj
-59 0 obj
+61 0 obj
 <<
-/Ascent 728.0273 /CapHeight 715.8203 /Descent -210.4492 /Flags 262148 /FontBBox [ -627.9297 -376.4648 2000 1055.664 ] /FontFile2 58 0 R 
+/Ascent 728.0273 /CapHeight 715.8203 /Descent -210.4492 /Flags 262148 /FontBBox [ -627.9297 -376.4648 2000 1055.664 ] /FontFile2 60 0 R 
   /FontName /AAAAAA+Arial-BoldMT /ItalicAngle 0 /StemV 165 /Type /FontDescriptor
 >>
 endobj
-60 0 obj
+62 0 obj
 <<
-/BaseFont /AAAAAA+Arial-BoldMT /FirstChar 0 /FontDescriptor 59 0 R /LastChar 128 /Name /F2+0 /Subtype /TrueType 
-  /ToUnicode 57 0 R /Type /Font /Widths [ 750 750 750 750 750 750 750 750 750 750 
+/BaseFont /AAAAAA+Arial-BoldMT /FirstChar 0 /FontDescriptor 61 0 R /LastChar 128 /Name /F2+0 /Subtype /TrueType 
+  /ToUnicode 59 0 R /Type /Font /Widths [ 750 750 750 750 750 750 750 750 750 750 
   750 750 750 750 750 750 750 750 750 750 
   750 750 750 750 750 750 750 750 750 750 
   750 750 277.832 333.0078 474.1211 556.1523 556.1523 889.1602 722.168 237.793 
@@ -452,40 +463,30 @@ endobj
   556.1523 556.1523 500 389.1602 279.7852 389.1602 583.9844 750 768.0664 ]
 >>
 endobj
-61 0 obj
-<<
-/PageMode /UseNone /Pages 116 0 R /Type /Catalog
->>
-endobj
-62 0 obj
-<<
-/Author (anonymous) /CreationDate (D:20200922215030-01'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20200922215030-01'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
-  /Subject (unspecified) /Title (untitled) /Trapped /False
->>
-endobj
 63 0 obj
 <<
-/C0 [ 1 1 1 ] /C1 [ .862 .835 .538 ] /Domain [ 0 1 ] /FunctionType 2 /N 1
+/PageMode /UseNone /Pages 120 0 R /Type /Catalog
 >>
 endobj
 64 0 obj
 <<
-/C0 [ 1 1 1 ] /C1 [ .862 .835 .538 ] /Domain [ 0 1 ] /FunctionType 2 /N 1
+/Author (anonymous) /CreationDate (D:20221106165120-01'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20221106165120-01'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
 >>
 endobj
 65 0 obj
 <<
-/C0 [ 1 1 1 ] /C1 [ .5707 .79903 .8893 ] /Domain [ 0 1 ] /FunctionType 2 /N 1
+/C0 [ 1 1 1 ] /C1 [ .862 .835 .538 ] /Domain [ 0 1 ] /FunctionType 2 /N 1
 >>
 endobj
 66 0 obj
 <<
-/C0 [ 1 1 1 ] /C1 [ .862 .835 .538 ] /Domain [ 0 1 ] /FunctionType 2 /N 1
+/C0 [ 1 1 1 ] /C1 [ .5707 .79903 .8893 ] /Domain [ 0 1 ] /FunctionType 2 /N 1
 >>
 endobj
 67 0 obj
 <<
-/C0 [ 1 1 1 ] /C1 [ .5707 .79903 .8893 ] /Domain [ 0 1 ] /FunctionType 2 /N 1
+/C0 [ 1 1 1 ] /C1 [ .862 .835 .538 ] /Domain [ 0 1 ] /FunctionType 2 /N 1
 >>
 endobj
 68 0 obj
@@ -730,18 +731,38 @@ endobj
 endobj
 116 0 obj
 <<
-/Count 1 /Kids [ 56 0 R ] /Type /Pages
+/C0 [ 1 1 1 ] /C1 [ .862 .835 .538 ] /Domain [ 0 1 ] /FunctionType 2 /N 1
 >>
 endobj
 117 0 obj
 <<
-/Filter [ /ASCII85Decode /FlateDecode ] /Length 13326
+/C0 [ 1 1 1 ] /C1 [ .5707 .79903 .8893 ] /Domain [ 0 1 ] /FunctionType 2 /N 1
+>>
+endobj
+118 0 obj
+<<
+/C0 [ 1 1 1 ] /C1 [ .862 .835 .538 ] /Domain [ 0 1 ] /FunctionType 2 /N 1
+>>
+endobj
+119 0 obj
+<<
+/C0 [ 1 1 1 ] /C1 [ .5707 .79903 .8893 ] /Domain [ 0 1 ] /FunctionType 2 /N 1
+>>
+endobj
+120 0 obj
+<<
+/Count 1 /Kids [ 58 0 R ] /Type /Pages
+>>
+endobj
+121 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 13577
 >>
 stream
-Gau0I9s=3#D;Okcbd+nc-C/5rSn/#2fqaNQ([)+84(rZ^^'W.sdD'$]r74t[BfZL0aD9KB/]nU'a5e3jgns+]U&=rBT5M,Fs*X^o5DEC0Da49\(7+i<qt[_1J+snYdc,JcJRABGGJF+BFSk**iP+.I(]JdigHF?#H+Nt=(*<AO;3$.]ILh465hb7A:[>C-g\Q`8TDs#g@fF"(2D=flD_jWG@EnQBS*;!np@e*-h1#>PhpX"+epCZ!a6FBZj%F_:k]U;SW8^&(BehaK-]]r4[r%"X/]SEhUM1qB`uuMuSp%ghdY(\gqmIJS&pZVmIYenRm*+I0T@0E#Q%bHfdB/;qKqg':8'aOibVu2\+W)e"R&NlSS,]-k*ge@kEJoNX[pO%Qo$d!Pn>kIH1>Vs+$iDg9f@rG`iN_Oer6$2*KV\LVbrcI*:mLSrs3#oKrpURaC2>jO[oloEn,!e@o6dV=V65lsT%l2:=7*Qc9+8<+hn!HFmeM+/e$e0!J#f0ij5#&WgI]^D4/_`+o,,P4/[tT6]'%0DV8Kk3#p3CMn'ShY@46#\DYP;8kFBj>lB_T?natN5qPWNBfeq3+gU8@UrI&D!-`%Q%P?%aPEr25B0B&YXnRjO.#i5_na9BDl+:Pe'(`.j#(BicMd-6/O$b5C:%M)\9E(%J>EDLRM)SrjlEn;;I*qpLmcoiT*n%s/f"N.P#6V7H,>)Kc/I1J?,Ft&ls^Df?'Q!cdfP*^dq=O3=cH/>n-/D!P21nThXhS];2UNq)9YRAkk>)l*.pJ,:8/Fi4aO[h1OXT:T%I1H/B'\,!7o=Q&fid":[ja<Ydq3]"[#Su%`4N6nH/UP(t.Ad'j7&M7B5>CcAZXk&Ea4?X,dD'lH$ZfI;?'n8KY,?9O+4d=lY&ehFN=FaMY4m4qVrYH#n<Pp9b?Ie"]EM)-(gQ+fK'!sfb?NP-Opu>4&+'.c\Lpa3-47gunC[4GC)MWN;M7Vd$f:dd*R@a4UiD<HQFDN?hL^/:Gfsg=q]d.SP&c@=/WZl;ce%9;IB<<,Dq]8:%Y30t@uVl&UPlU_nUu=4hXcDKo[t*XfZ1G^[Kk9LA""M83LoRS41X7a>FqIXk:Ps;6r=etNji[PmO#%sGme<dmt*7SK&BoGL0P:K$UUa!JoO*?FMYgu9&N8O[58-/3<r%a4i`GDP1ok*jW\IfOTH%c*-Xs5d>B-T"Rj3)LPETq-QUCG6`j+aT0APir/eu3LdcSGXGia@Z.?pg\J^1RE'HZ_7iY^AK4sp7glAq4RK;a9$ckVhNk&p.XHtS'dW7BUC!X-;V7q;J"KXdK:BT1K(G5%MWIU8!*fkJo&Z5L!lpV/sS*MaS-b5La)[]Nh@DOrT$ofdtLP5ba"n/ZLjKRP_(5<g;rO-jQX(s1&IWtUreZ7lPgK**j<O>QL'`Mt-D%#SY^29Fff/Xnb2Whs4"at7$CMhP:5>lle^LiB@f8"QPrYgh$c7GQ,g"c`H)4(pNBcReJ^nf*[f(`:QP*Ah*1W;'$`UdIp7a(Fc"f*-el@Hu<0N!A\((9N@&R4Qjbg:1sf:^;Q4C6mur,o:S[q@</5"EV%Srab!XLb!qF*o<EH;[p@Dic]+-h)A4+Zt=r'+Eh+%%a+*:LNYpSTkc&(=Qm;=F<esN#g*:NU?6JD/<jI]Efg,,*I2XU'N?e]<D[>c'#?!P)\kLgTdA7QH>IaA9VLFa!f*W!c+o\WhnrZa(isJA(IX1e47N=\#*5;m+#<?4CW`.N4jP$e"3=Fbk)m&HSdkjh]>M<_7)q`o5eFnk"O;510.[F]I9\7C,2Y6V,_hoN-U0^kHHYuYi$K:"rnDk_nqMQJp1<6EnHh>BqD_n6oEGgP%X13dpdHgB/PQ!\JAd^O_\CFodj)[f06@f9"1u#qckY*8RS%Y;c^&dNqLSsNG7qD>%Cka=JTLp7)Fg2.o>50d6^]"6,&MZh6)`Og5M=Ai;-91BlUpu*ge@kEJoNo=\,Z++_B`Ji*&V]Bt<u#Xb187/(luApl]GnfCOV)cX][EE\$B4'#b9P^]Opu!!OE?0E`dXJ:^N]JH6I,!_UO79$*6u[-r`cV'F!KfU\%!@U_9Sj@1Q&(QlY2'h)dBhM$A+,tk\,TP%bY9!b-RQH>OcA:J'Na!f*W!c+q2WjV(k8$mb7[Z":iZ&`auit_/[[[";g9t$l]8(j3m3QSX&cU#!NH4I54e+7Ws/+)jQgT%Dh2qjkVQCa=AnI;qg4VjR._LT[Yo2lk!=R[@>6QQWl@q!GgCUU(YeioB6>=Dbq`cgW]Z)tC0OjmI"s0XBM<=65"kg"n:HsH^4Cq5>g1$'/3nVW=NX^>9Pmj["]?.(/=.,CbjVUX$GMPbKR-`@ZBf#cI%dRq7S@r]8QdVY#4^2B1DOr:*#D&CXC-oNR0E7p"ML1%B!U"nUbNp-ddj`mfj7Po"fcn6:W/fa#U>ACV!\.7uR[1t=MG.4AajE^XKPp;poqf8JrDQ5hibe%nk[c22QWj<[:)Sj5tL0t0+<\OY,0X-.(=Fl#<FMb%18'9>H\q@L+(F?#0.9WTm'$6P4,%!Z.7OsAC'"eU!&e0D_M$jsG(@)^8MI^lZ(AVU<C\;@C)*KuiXnAgpfseI$g$:.nN]_0.<fXh/aJH9THCq1-[=$8,2mkO+F)mFJ8[fk8F6E^]4r?O,3:t#eqS8j:L<p/HI5$>gAo0-7[9^!!F(kJ&.bE8Fl$,/Qe^L\'*QrqiO%r,`rqh9#)DV`&Xdq/)q;>ok`OI01XdmsiE:^2Vmi)BS>K"%K!X2(^.:822@!+gX\B#L#7GR@/[O,B[AK)CcOsLrV']_qcb+P&a6$Enh)WEK+69Lj>=pU*l/@7_4nIu,&W-0)2cAHA-d8F^pho%(A#hFfPeTFepZVaIn8uq1cAmt03*`"JC-h)A4+Zt=l'6N4?%%a+*:N^MKVQM2l`K*!r:Amib?+#ke?:5Dd&P=f^;1t7n?.akZAsn?`f;U>Khc1E5lq8mm40^bFWHtkc>3gWV3B_^(=4Jq:MQ:Jn<'dO!f*rhZ^aZ(Fe+,DHh3<_c\&h3UQ/:F5*d?O]#6VI<LH??g*I-AU&FR?o%YerS/.m#FJ[rTGEf"I_;mcQ_J4i:2;.k^k.0Gll:+4!mV]Ntl>D\bZ9CGf6SF:(B;OX.DSL!1a"Qek/H&@Qs:;m*K8jn7G<OQ=]+Bloa7R=a4$$g9R+.d/f!eiWsT'oo.dXd5V*4K&6U0HR>AnsTh-##?<%X#&].2%%BCQN:+,E>dU9p*N:0g3X\Ut\E[1QVYK.2[XNGY#X^Uqf5&3["Y2;U>`L\k")F=-CDZ8t7?-r[!W,g.<P[,)Q4',oNg56;-f#lpW@+ef\+)C5YYo<CJ[T'8tpK/5B3fR4PSn3kq+Zr/0f-f7(^3Tdr/HoqC]+gGeU+WCjPqc!NEK%d.bN;Hh$uG_8L-397mUo"ZCZ#*9'2Gqan6nAp5*j>Di9SZi$t_&IF"@t6KXCNHQ/_1-bh`#GqH0eHSPR$OXR7NPusqm$-=06tGur:g$>%^b=^R1*E>5VZd%\%=)$TP03#G_5M-bCLM"F^?-eG8V[S?aR/L='=_J;,U85Ws8j#15Z;_I5u"8/WV2a[1n2k@)!]1?_?Ch)42hfEJoN'^r>I:-fkbQhI"PfD/XL+>fSg*r4+l.Z[Q9%cmMO6$_DHAa3[lB9j2\j0h;Ck7)9G/^`s2@&-W88d"s/)Lk8AieTD:g\ru(g:Z;L2oe5Q<eW(jN&P;%Q,jeSYR4Q1dYS5CqfT/#f95QCBXK#CbcX3b7pJT$cO+rqIP;CcN[ouP^MCTRXDT.m"e+RF>N*aJ.d.j7QRY!uOq>>A6cu@8X-b5La)fe+I6Z=`4!>pE@+Ul-t4:GX(L>ZJG6SN<l1mT`e/H2cdPECGdYF_^n)0nUq&QVbI]jb0P?Lc5`jN@pt/7NM$#l4&.4"MT1cG69`0?67J$BogEc<-Ydb7snC>jnP!+_X_a%np%Pb9G(WaBKoU9J%Uo?PG3^iA(;a`+7Xh(#ZU@65T(<F1@F&`>'nbR`0Eem9Ah-<#$;`XL`;,'fL[.8SL&q5p$N"^dAE_TEH<.0E`[U:kDFjJUnGU6E)S<aOHJsY.,&+HDuD9"KQ\[fmu[<rul*[P/_#=hM&WjD3d@VSsS/?)H^"E9Q%cmGnPrh7T"mU=DOHlXXF+deV[!YiG-=HDie^&-Z>*@`CG3+<#8_EkHCALL%@>c.BV#;]YWV=*<'=GJ)Kf$"8DtZ58_6ZGl5AhrgH96cLlX8nbo*mhCuE`K+onlGQS[4$?)T3`A;F7k-^C3`!1-^%d/)+2rkAu".'Y8*:tL.N$g#h/5MLA$@<u"G>kp][&C88-EO!(%:p77/Wq<TQML'-Q6K_P_diNNJ:&mM'*U@5Z-^J#m7#^&&a)p3(0;)Fl4r2E*2Kgc#[u8+;m3DK9M][Zkr'0k%$n\=$&5Ye*_S2?,qrGQ:+Ut4&p.T^Y#i]oQ$fb0&1;h(In9gEFqiV^80S9_Bs4h^A-q+Hh'XLA*$ip)D(uR&W`UT4@ZaoP6lDaJ6OU!'cCsqJonmO?id/QYF-(]:-ZbBT`CH>Ke/);+kHCA\Kl]=9.BVSKbeXAm)usCIJD^D5!rrH75SsPFGQ>Sl!1RPXc4rQ%R"LVTHM+Y4K9RsBQpW<,*!'0a(AYK5-Q($k?4hsh<OIoQ_/K`NWYX^NSm&P[cgOJ0(r-#@=lZa_*-:&1Dkf;`f;(rBlQ#M$nkF5,)8f5f`Cq^e8J,IU&<)o!cr[REEM+DQQfGL!1"/'Sf`DuPj<p,:hp''i"%A-Sp+C86<Jsf#+08X.l*%*&nt`f]6'L`;(=J)P8ZU^J"_n$u-l>8bGXT@ZU;.lY3Y;N";:(/uVlBnr*@>g[P9e>0r@nO.g.<PS6AaNSUpWr6UEt.$Fs7h+qiPE6Yq78P72=#Dn]Oqq?E4k<BNQ-83Ff2g(u4cM<`6<gF=SeDS@(R5>+GKIo:KB;d/@c<U>^4n\uf"8Vj!>"9"GHlSV&"DpqZt.^qgNci!1<P0EaW0n:MnZ[At$@kZIGCes@_j>1'=Ip%`+"<Z"8reI!Q4=KOP+&,b#o=59KPX5LaqG_\AFoIIbDZb@.D1ae7-5q-;mSg)VoZq7'd-fS;WQtOWD-d*OQ.*,IH5E%0A"'u]*,>ZcU66.,NFb1LO/Jbo?(S65KQ7=LrOd7K"8;#JC^5"OY;;jWd<S))i_Se)j.BTI+8:uI+GUUB>Pe]WmL7eYR9$dkj0Mm?r-p?*1Gj6u@b:Y%h?L3^Z@*q^n3=ngL5:!@RXr&b,]<M%*c&r9*mp]MDre`1kac/i%:L\=GF2_gD[FY0&r9R3WWjqUI.90WW"YE_ZBp9OT-eX(e',o`iYM0tLoenfZXjS/)_;c"FmU-$=i,Ao'\-%dR(r@;<gqaQig,4c%<IShi"g(XDl=k.%+>o#g[X^4BA.)M73+33mLD<m,Tj=?_n$@_2F!]IZWg?&C-A'DIc4fg@'UaE;]r[MOLq)#=jV_"HdB\H]$M"p+$=h9Wn3fn]kUT*tQsq$VYB<k`a"8(<kSBebRhdET8:VI(/mCr%id9m@Q4hIF=EWG#-qjWiPMAdAN<Cqf-1G#g+Y82b&e&1T%$mP"944t,SQL3<;"2tClBZiho"*HqZbE0)7.MIbfRZRslNAqGJp1Yt8]fBac08\A9)4>oQH>1YA635[XV8WdJ[O&heFMs&;P:OA'.Ha_n-(C?>jqp!9RN!VBF1BkDZ75L9NZM&PL:qp_&#6'^]=rMJ-QR/0E=6)^k3fgJHm5)!O#dskZd4[CC;2_9Q]Q6nHH$gN:;O!R>@p38!oA'jMEXZF63ib^>'^mLfLQAW&VZYp=R'1J]^AcgjXp=pUT53Dd:LuBQ<R3TuG"<7i7HEO"cbeT1@26;=_dV?tBD#9kAo[L1%A&62)VBS,]/AH8@Ar[ohk2)uUCi3iPe\li,&FBmZ>=jhesHim/>dT(VutKKa(L61CDV_M#AWDUPPk0L6Vm!t'b_"WgJo"=PsSJkeR^!>KVWW\-ude<QQ+3"dT\WIIM6Wcf#sNDO(;,&+#3_dj)1Kmec3^i%*4>\]2-?<+s"J(ebi\c8A_;ItUYaVelb=09eT`J'.TYN!F;C&>6R7)Sss@?;uQ+7qcrH"_Jo^MYM7cKjO:[utVr?K^e_%Y$0_5B-CM!W7Mh*t7*=4T8^oJ'H,(S9stu94>B09_@Uam/nc%$*1!\f7;o_Et'MX@@:V;&,RYuLb82%m.:,@+hp5rE9XciK:]a*7J`=UJ"e.9c`3;]Z3Lu.l4"?A`4)J^=%5L4+tn2j1-[tM;?Zi;pO#Z^%ZctA%?\X^(:lK74iKG'2I(t]aYmDo#"^_#'5ru65U1k\f1iQe7PI!IXea]B">`jU%j`'E&pPh@&<ssq#s+a_#"m5KV)m9P;chhq`.dtdNV\tX3RpkK3=ngL59qi24!.UWG@Bs6+g;(=CDsV"[l@C,1:\!Rlq&`\eN4jU@'+SNZp4F$-QB5eM3ABMN'WU9f.&f8n571JBn;Sbq<KB^i;?;E8uq^kA+7PALHHD=*]W5s!:moM%u-/N*dKGm]OnUGF/=p,`ZWrh?9OW:#7iPDP&6S1h*X.DT4Ao#,9>CeQQ(RYp[CuGCr8=2rWC8sGmeh[Cmb#K[er0Fds"2-]]s\pSN"$7n@ZA-K]g&*_0"P/^)NesaTajcaTcJtK$dI!h*`)ure$6s*DC2&@\F0J%h<N'!e%?T>PBKa:>8PlabFlUT1_()lhAL*IF+3[i&Q#'#&V?8UfD'5JM_l^'FY!L4J6'f:ga8,SU^bD.-Le5SSXCe/$EC@8GnK;rQ?.MC+%DHM(;n#;SBsp=b:j++/0p_)tEeC[Dg`V<Q28u&m,!f`Hm;6IWEG3\$b2elrBQlkk-E#2Di)33SAB*d,t0afC2*#1V&1)e+r;VfAN/o:3%lL2WSriIc0,h"7QBt58\nmGkf)dr4p2\L>^\-29`%4;i*B-Md/WQSuJ!^i*:n7eG1UcU^m/Ma><+#]T+&g@D/NJF+ZNtqslXhaJLb2km(c>o&StGj;n#21jP`<]+&"*lA8V]\;=>I>>a0+UEF33T:Sp'ae0FRh8#:c*?NfODUQ&665Sb#;j<K<5rO>Bo?SP_8;$gIns`1&r*6K=^T-V^=-,=hkt,SH]g3PFP/&:KL6)NZ8MGfC0M$dj,_85oF<[^`'r4N/q43mt&H@QFqNmhAWHJpAeudpq,h4tBOsP>hG+Q'DdNCasUUKsp10)<!gU^B)M8acg8@$$7leH3'Fsm8(jJ=s.Y9:%$K)>uHMCloQ+@"!ajQDCPDtDT*Y99CFa[p33hI$^4GMmEF"1SGg3uGaRGhg+Hm_IimL2bcB'kHJW5<%5Hr!K`2:Q$gGY98VQ!`gY0/RW/LKIrG26l0'`%CT(_'5t11S82]k;MpfNSKr_uqL5WGIj2KV83,I^=RR)`=Q3O^^al0&B9?^Y[EMEb2`jKLS1DXLDF(9)'*U@5Z-\36p_;S\0[U.q-\[C-\fc]`Dk[V;6"gD*lFJE<fDqcr\Wq7U$"*s0i1U9@:]_.R(kNA;-p]5F^d&2eTi;gTAEleH<a:He]%"LUHrW7bG4ST$+-Pok%*9-p$[YZAQ7b]tQeGoc=&lNl2BNZ0@^4e4O=[We3e(>)rJ:mqfD`^BM(?:_Ko%=o+E`O%nc^Hb[+ro52g#GiDK8WY`AdRD#9Gk__#Wu?!=oBb#9J+D"?c1hK-B/1lOocSHu/9UWCumKC%2A+9+:=oX@i]P+u:=5Hr`;h,phn2\"hTEAVkZ(p@[oVVdQ/O&K^^)F@ts*r[]Y!IKP!/'JmXjhofu1g_Q=LjL3."6bSiF*(k+*o#LjL:<E/59&iM^(gH,:EA2_WiZ4sO1$KIA3\XT"it`#.GY>X$:0j7&f):;Ze+P[YbCtdo`LeYS4R;`q$%:0*K*_<nHo\1.\1f).3XZUs!Bd#_#Z0F["[deA""<@9'Gs)$-_TbAKM5[nfnq"o6C7OY\p&2L'8d`kA2hQYd7S!f/]#Xbq[fT>fo78FMesop)uTD_i_1o7bq[J<+_CT4N4$s3en;2G_F1S/EFGU+<HV`EdI=\#nNln*KnkuCq<PIC@@`ES8h2>a$osl2+#s&3!;sXK%gLqs*e#dG5Oe/p+o!o&'4L@_8R`(n7:Dolcd\t6E+-U5l7G[4h>Hhs4-Ydt+6;CD41+;dTob&=\3i0FED&;u%XF3<-L[T1n`4mEjIdlpg\k$cU?U`h\`mY86V7*:ZY266>>>C97@82k99+.>>jk]ait`#.PhVe(S.m;FA'A(aiefQ`@H*bIK2`C#nZ06=$POk9a[p>,]g3PFP/&:KL6)NZ8MGfC0M$dj,_85oF<[\:9ZY_Ke?*s,kB3agApl&9s.K,t8Trua*N^TCd1T+aZh(!;Op91q@TuJ##/C22GS,jOhb+t7.jGG'[Eb?:B6W@P`2,P8@H*.r87CM8/P'=0UMN4G#VBudf54s5H5iL+<p:(%i,Ju3G;+P/E4CN$gk!Kd%,h[YmU-<Ec,)m3.R,lEJeTPXosEA''IJRe!Ym&6mX'5r(<S##He:Zk/s3mkr@V<q\Q6^%V0G#O8HLluLO),^'A75Mal/9!;"%;<=Q4-P"h^#g-"kV90Xf2>U0r-nj>_q8]()U,N"s^L`BkBt*`(`h$58EgG#F^;U'jkdpa3Qp'nf$VX013oKF)%,;HcY#@O-IA."R-d$pb1^P[Fbh@%[Xn:]^_Fk_)i>R#n9tR9OYS:?tf-9_qM%gHfg%P3dpi3a0W9UEu9LB(&=5dKNA0@U%"M#/BPu\.OX:_b2!p.jGG'[FUt9l.M]=0QHJU>aW%\$W<A%iX8YOpaBL2$:;qlr,l52YjTLY[8hU,06lE+"!.jN%ik(H!-mFQ#=H9/%m1[1?F)?5\^&5"?]`,mYFZM:OM\pI?RUVbYipP&q7'0PPWqCCL%',tM*4P7]#<XC0*d^8)Fj!)1Oeb^e&_IG=\0jeQTlk1lLuV6dHu)pU>,&j`-Q@=&5-bpDA=nkPYjiki^st'>D?Om'L?rT`1(7B63ehEkVL%kJW"F<UW<7\_uHab`8(#CHS%s^[C=gl.8?<^ra9I"8Uja/OCug<#b#pDRZLS*9j74U-;Xeh9Yh:;^gd_+0EhYZd"s2*R"A(,4d@@=l7b0@^*L6tqVlBB(YqQ5i^kEKr@W6"U'N?e]<E7%&D30lSVq>>gT.>VG5GR&99D3c)\)A%1Y+V-RSOqsWY:q`-.RjYp8?Gt<^ZRGWD7id")[_)iHP:4WD5FfPEXco\deJ+6Qe>k_>jYR+V4hh#TeONKL##4KHUK,WtV1>_h^Hl=4N.&4]AE*+k;E'][\;@#cpdk&Vt`#@M!U=6-L3a93g@`&1-@/\E059It^pDb4LtUh*"T#UYG$r".tDBp4S5J^(l@91(&%;9aP=Qae0FRh<C*?>reMBm0RL^@\F0OnLW%$JYL*hSdH/Je3OHVha8Ek!-''sWp?NI@7-ERPZH6PeA6YA4IBL^9]3_i6XTrt-KkRG(be6'R%=X!4E[#>Ag`a00n"L0g;$E,]+@PWY=fn<-pgSr0'kf:Zd_9^]@[lt^T*0&\(@JO&rC\Cf-"4(X`Y\mS9gFL.'>[)C(qJS6#./NS3^p)TB$DaK4m67^M[d#cJdi[Zq>7U"qNk9d";A_JV,!P5S$!L?jM):Ta*s3CY(!2f(uqn)72l\WMd]QZplde)6cS]S,mC>-_+V5V_67+>F]-DE-mp-PdDt"Q4qI>.9]:oe#.LT$"Q'->qS.sM-04?LfiY@;9UPc+D9*70Xf2$0:JF<3Rm#mmW,9/'*U@5Z-YqLF;EiB9Q;-4cH6h;Ud<0<ha8<h$um?+Wp?NU@:P[rjAs]G,_d0nJO^@^Ta<iM?jKJ7cifnQ!eVi`7+5)&Ju9*b`U$$V/]Rc9"g$ETA03#;mW5A&'h)dBhLusu,tf.5_2E.bs/W/%G5GO%1QaZKgC05Kelq67l`!NKV;fq"Uf)3K)RNC^_&B[YnO_<)Q&(18q<OnUiB0k18uq^kC[fsYLHQKi*]WN&!;=3<%u.:n*d]So]lp6HDmbW8etA:c:-C2[TTtBHekdh2S*k7+4mu7U+49QIfPesV>pkYbh_YZTaMhbh@%^8WnD!,jkN/noEY=a'!a8L?amVWbgt%dlgY$VL[io!LEXD3>@^O69?R_,\M-t-8Jh"j^\trud*A(4'r?-M7R)\Kefr!ZFYQ%iOSUHg<?'70amZXq]PW3OV\XLI#H=)hsa%F;URV>ibO>bTYg2rW*YWk,25X0A+5mR7[!t$(4JIX)MTEdN#omu;*,\>Xr3+5IPeBQ\%j>IHXs!Rr\#7C-aJN3@tSt,uPbl5FM>&9!Dgsp<YaBjH23snRP:4`%Re2lbFqm3nRV4l@D\Bo3Gr2e1_f$5'-\BOG&T/'E"L*sOTVT*",M9g/\mPEoq(1^f=#/),]$SpoL)*!^D5KLWk%/N9@hMeaVc>^#5Q`K^&lrTZRG3YK!KaHFkdO=C^-Z$@1jiK8BYP5\Dm_pA72\u5e-`jfaa*Sb&&j@`h9-I!W[HIUXbY<QL^uY3^>hp0[CV=TCMCIUs(AW?!EX#+g@^AWL>)maoaeW-:VL#j>*%G1RU=S?RC.[*O'jg1*_=d(GFbB-ch'Kgc*g?M5;`$0_8^9nsBmb&)b^dS>oOA(FAtU5%TU:9Ob^a.,H8&86#^Dq5qNP9<;leQ[jB[u(jGt=V#j`?Ue3!TefSb(LMR8f%?.,_)&<j5shqX:K""!XPP3SV:E6uTclR-Cmp(K%_>kn]X!\Td].0Ws-lV\&ajK^BUqh>KhbGG\U?&6fuRl%j\4*6$B(\FF0/@qJj?/X'5rTF<<0'Gf,He6?Qj`kYolagkBVk2JFY.I/`/F/\ohfR>gk@HgFTlmoI*uJfFlc[+[hd+fSp6+o:3E,ni4==+m6hub4Z04*(>hr_KCV@F=MFlZ<QM#WHEX#+8@^G*/X_)4\<B#b.\jp;2\+RY4Z:-BNa`c)j@38gXlR/,!l\/Vbqqn`a9+Lq`.f%77Z#?A"SDuN_B-\rUC;?MIqG@>)2:.C&:t.`@C-YVu4fG?DpcM=u_o^3?fh^s=;PVA$`lG5Z"SN6<lE0i#lpX)777q0#Q]*:M`-ge6GN!$:6&C#CUj<D4qS7P@?eFNT:Z792V5J:LraKT.I/V%40'W4.0("g&D`ElkCi]4"M>3UJM;q7@_\ZF&5qfsfiX:)&"V+ndO"YJIJpr*T2gF[mP%/;ZmCL,DVk2JfXrBK0/aWp0b5;7#pUqfmm$M]_a*O;;F5l9-[81iUo,h3We!KS;*]o:J80"sfdWW:Plpj:'N_/&IDc*he9[gq#oS'd!LW?NWWB\lbfI"2t;,i$2&b)qf8Dk):$61X#KMP8m\+Uka.JAMLfpi"b*"<=ufc)!PhK<%^^$@j^p9+:5e+rpiBf>[N2UQZ.U71I$G@c,H7&lu?Q7Qe*HU(9kc,[i\/><`%JMQqrj0dCh4"]%?A(djJ/UnP^oD,63D!_[JTlc?iRdA#*ra6mMp>Tc-U:.bY\r48tf[uZ^1h,-i[5[PWY4e_P)gbLg.spmdF[!Q^RZ5"W9m#3dW$Zl]Y!6"oQ+].\ZD_VYr^\KmRu`QBjnkmnLmUsUH`(QD?.R-M],[NmgRIZ8oD,63D!W`jU?`jh2;;@'9(pD`6j8U:/:(anXRRb^>C1"C=#iKVlobEKYrD)/?KF+:Df<A)cKCNhZa%!HM6;1>eRU>iQ0k..G_Mn=Mq[mM8`Nf72YL_pNL5of=*(\;.L$iqEgEo7GNO.(,EY8pHY84;g-(=.Z5<!+K7u?miFp?-[_6,$Ga4>L]id`J_X?D`/i]fCo4$b1][ZI$hd>R<9;gIq>M;Ks4c4![([q3QKfWQ!BZZtbp.cO0o!,TH&d*cE=1N.Jp4gi3X0C.E.c4Uro1Q"7fN[&tf0,"+[PsRu,pQ;&'?.#"nA9ZL\FS$>K2p=C^:`*#'dam#_GnRUHuGS!0:cQflU8!M]15`CZ-%bM)NT1H8#fU_3aT=a=lk#G1TU<'PTh[!r="`1OdHkUbcF?EC*[OLCI8!<XNGsR>0UJ)UFfsS'3h5^6m>\\0tSW$#Tp)roLeIrATf5!A9MA^C3F45BID7H(*CP4-<NAt;e>[60/oHQ0/MG(C`IAt$:lG&71t_6Q;VRCq4>t4P%L!&aKohf8-WV;=[ZJIeZcPdZ\`>"[+AoFq52X;AZ"4N*Q1]R^uAhIB!0*NXNW;-9C-t52UX/s(30HoD\g_9+ZCr!@lDdfQIa4F491r'0/MG(C`IAt$<WgXfhAqY$C0:uF,=0UbXU0;_a8)\j38e%+rlB^-ItTuYqD?.b3V4jS^oGMh8X7NDm0RNS?1D^]MMK]aD)(T'"_J<4_mSUL7i/)*7BN*O;Mh*A+ISp</7hC!1h[o1Yp&e*,i%g8DJ&Q@ff-J>_f]'^r3AlAg7Pu@3JL0nR`AM&]V__%;F&&G_YLFQ3X)3qIQPYRQY^_'*TWc)q(+/YuHLc6H$gF(M4m,_dO]qORZopD%YdFU((g1`E9--=rr2hl^+#W@lB?+=9U80ON)C$V)kCe4skHd14.H2L=AN6T#Aq465hX8Ou=9-KMoA6dqSb9dr!=KnHQ%E72s[BQ*F;DZpMsSY#i>S,+9$U)UF3F;9Z?)N/8EFFZ@Q'f.$YR;f,7#31Pg,(0rokd>ZbQ\;:?p7P%b!OX#1<F,ir?dQnk,@&1h\Gn>g#cVS(s7M<$X;3RCal:6/TpI0D:KN[Qm1-M]?&rE3R`:T!6@?%@c0M8V9Q.^k_OkGFMW7h!e!GEkP+;Q'=Co1i-6W7PSc<_'.VSb0$,6NBs"XF^D,DkV%9;sh]jC$S@oF*At4i:\OGED?,&T&+$`8YCR-@3\[?CP540*j_i@9KphfZ=J&>`@?0cWH'ifnE:\>qaDkHA9=(mNCQ7,2+5'LrEoKApVJF>+(AV(PJCEY`.8VJ0.emMmG.-ko!-f1:o54Z0R+s8C)6Wa;ng(=[ZJI#Ed\-cU]7+`mRbQNO'FST'<J<fuS[c<WS,B24NeI9$/&T9js8qf.41?%;Em(eEiSjRd_F4UCCp2cZk30OG:(XKV%G4N7l:&+'&E!]+&IJcUaMjOB*3pf_**tUh;Y<j:3s%/>=`5K35K(NTh>,:`[u'p4CXI*L8R0k)^ns8.7DP0g0$G%V^VoMHqmZ7XBg,6LGuVbp(jc4GZEFd[6W2</3<#]ccr@LLn\!#5k\4=L962ko!-:81TWsm!<7:U`g3CK:4r[S\^":VIq/k2P^YkWb*mi4k!gWZ]P8QX9'/S87Qtc;B=0mUD1=Hq6l,n5+lUP,:5f5bD%gMB.VTl$th0u4jtQWP:$iQU4>ZKc?qHYc7!QS_2MmW%K6l[O"sB~>endstream
+Gau0I9s=3#D;Okcbd'roM.KhuBA!9%2X-sH([)+84(rZ^^'W.sdD'$]r74t[BfZL0aD9KB/]nU'a5e3jgns+]U&=rBT5M-qr-\D75DEC0Da49\(7+i<qtYHFJ+snYdc1#9KjXlMpV6UkFSk**iP+.I(]JdigHF?#H+Nt=(*<AO;3$.]IY'pe+RR?q?QV!S\)[L,5QBuX`Var/D-lWbhe%>m_j^&c2q-[@If?P*cbIVH1u6dV5#;'?I.q,mBeRBZm`P\Ir5Up&*WM>D(REf6`P[jKJB'p@7,j7p4RP?!Hp+83Y:fQd3CY:bH<g@\1!J:<`T9:[6\d-!.4_/t(#]Nj;3$^/LPD175V5>W>)G"4T0P@86,u)A;1R[B$bpSoh#?D:[m.d6J,3`frUh!%B6nNHq.$"QA"okXZi0F@On+_8bCACJn1/A>+*Aum3orj@Ah(Vm,n*Kopo/q?W<>#BcoIA!V@kqf&q5D(&4#KRQ=c6))<;4"a+;+'G!Am8aP'32!27@++c/]>MU3!K$_rK3^]7!]I=%pCC%]rq1;Sc77M:XMBNQ-83Ff21;g?=2FprZ]`tP5hbpU$sKRrq%2kMcXTA\lGL?90II)=6X(/UF?(.,[;H\f.RJ)!uXPD6P6bI6R&p://1j)L*?;^4V`A\%9Y[.Wa!.=/r0*;82;U1WdM?p<_4(P2?`cPM.XhN'D2lUB_qc0'_KpMc`Gq`MM$(`b>a4QCMG9`;[_QFP05OAbP247olaoEa&):@l+<E8c(;#JeY%gDKBnS_!+P%d,'?[Ls82>&@3*,Z:Kcg=8)5aY"0>nU;]<#"o^\>)Gj7WQL+AnuX<HQ;LJ_9[dmGLibV5C+04=a`:'0&s%<GU&`4c(>@t3@s#Ae[sOX^@gsD';o[R8)'j:@j#1\R@J6534Q#FRZ0Ron@1V'lHZ&]n_l`pImMVUC4s'$smC2rLWos#!pR]iWd^.-B.6[Df#-q%JXo>ftGqqa4>rl#lo%<5WO7"=Lc,>8(5KAcool7`"natN5k#]m\ZYP4=88Pl5s--a08T#j1Um1qWgcjlTfB]JW61?K46S8Z$"_#IU_71V0\f_h+KME>b(Y!Q"E?r2P7T<.+1_ee6CV<;D]'fleH<97ummbXB>M$IQo%'(eRr;SRGdS)>Q2uF"ZJ>cB]%._b>8N1ZXU@o9q-W1K?5;&$fXJ$VGTQ"LCHY^*s/N:U;-t&7^pbpY2K)mN1'FAK#a;oDiQZl!nQ`aWd(%%]]+2d13Y2ebQZW<*[+Bj_caXIT2S;96Td4>GT%!7tk3<+g?-]2?]!(_&4h'NlQG)](:SRZcFhmW3M<:B'4Gi3KG/f_Z^2:FJZ#\&Cc&_cBF<*%u:M/hj]af\t:aKL65J+32<7eHl,RjL-d[s,^4t3VDS$_H_#E0%BG<m'd61?K46S8Ya"ejBK_71V0\mYKF/lPj.q]th'9-Ns]YDfKP`5TBk9AC\)Y21eQ'"eTB*?"ta*e#9.[eRS8W`YkZgU]cq(?auMP+S8Lf#FD[)2Hd^5=/%6**Tg]iTb-uBn5f*onq+Mj+Zog]10S^73]/&E59nnBCrP!SgOQ>cd(!ion']BSt??l=m>HipD78\?dE&#]VEbpR$*Zg9"GIc.Hdqn*#8_u(7`:ZJAZt_=;Z'\n.#gn%bj_`*UN'[/;E&s8-^;bmFBZ`ZlREb@hnB01kgGF@]u.P6McT8U(dAa+)aB)\Ah2<g<(1Je%n7HI#GaOM\t'$G?Fh_Ns3f[SoNH>!uDiA&Jf($&Wsl)apQ_p<j\$S;33TQ0\OG:?o:EsoT06P*7O2(a#l%QJE%CQmCJE`lUK+FD"?2Nb<_Yr(]8E]%C]t&(-Y7.@\/YtA?<A6T6#B,@sV$V9lH+JK.$/5Jg!7-`tJm?#n3Du'2N$*"J'cM1)A>Na]NpaL5[.rUQ+[2&T)>sOh:rGFs<)o[%[gX_7QoZV9P1.R$*Hra4mkk5*j<W87ZpROiJlmciS!bFfMk6<6&b#-=bW+f$m40NjkleAF.iN<BO`=RuG%,PLH+uABaZcI![\5#N$Rscb[(\e+7Wklr[4oP-O<KiC3Y(R>gB%BpINtA):Y13@kRu/3&E=!J^jIYV>.Bi#NSf*4@2(=t/_];9]0'</Na0Zril"MN"9&Y(\_XjB>YA3_L4-[?#+B7`f?"hre0'S]e76/2FC@P%2KFP_,4a.5J%=/CH9si`me2&P@F$=t%NAaB'YE9J(<o<O<G@f8"B?MZY$H<Pk3E/Jd&O@CrTY23rrk7pRs_=r3t7nkEXf8em=6<a@X!&0&U\,e&qS,>lYb$9Xth#Z0F["[deA""<@9'Gs)$-_Q-/V3EOa9)EMI<]X]kM;@D%,pmfA88a(nHP&h3>#Bs=i*Fuj;R0j!#^SCPV_n;8A!rjD7.quDH&SI+/[3f0YM,IPF[Z+.ABT5J)Z//f3aOPuA6Wd&hIKjEF-LO0SqCk&oGhCGVWT)V1-IkB[aH4(ZE<D<G,+GmD<XW+(#ND'hIFBI/.?bS30/aoNs5!W0]]Ls4Vic7[U$E1@nH3rE8.@i`O9gGFs-Gmk'ubOgnpi.(N/ha`Q!r6%,5:7/'?le)k1'^lf1->S$PaK"TtUUPgbk#\jb#2DXdj0K$l]j\kuZ,LPI/CG>l)t1"4a6dT/,uFK5iQH5X[kAK*9!:s0E/Q7S7^I*j\I]WrMQ<S`JN/Jd&oj+.SnH0^cb/N0cLqf?V.9=NaEW>^'=rc@2BBDoOaWK3MuO$*$:*3$'MS$_H38!4)GY_"$#JVOsK_$UUPTG(@6?j3+*WlpM[Ff"LKm_hO#l<d.!WguOu-BcH::m04`,.%LA_Oa._?t\JN"LZ3pKrQ>b?&D)MdJI*1)HK='c<0C]4?Pbg(De9BSV?BlVsVgqOd?Nf[e<#]1W?\de+r=,\E9;V:3%lL2WSriIc0,h"7QBt58\nmGkf)dr4p2\L>^Z7Y3"9DlNM\HNSd1HDlnBZ[#8_?qOccB;c0(bI\=3*'Ea8/-PU&S8D:m7/f@,/WAPdYHn4(N#/eLt0s7KB_')\@(Z[_]hN.sp1'U/ZpU_lW$(+]FL6\$7)+GJI3KqrJW9%R:>m(LiG`8m=O/Jup6K8gh>nd]C;,GDMV_RD:XO\7AV7Q@pgd9.kNA+F>2q9c)k4GIVRbls<##O4Y"[deA%k&7r'Gs)$-_S6T$9A2f=4_!J8fCtTM0&%5^LZ8&4,N#f,`rn:,bl)CBF3OLI4/ru>=a46g1'na<KYMN`$5!jMc5nB-O[#`cE$)?YN!.IV,qYBm><Db?1#5^iu:OC<-)7"k-(6uOn1Ik.BV#;Ur).%*:@27GMmEF"1SGo3uGgTGhg+Hm[?S=:,4L^84>-DNKB%kh`#P;a=?I+&g:o',1-^0=Q7iJ).G*RZY\lScB'j=$sQ?2F/Y9Z4J&2s]f])Ql0j"ceT(j0)(V_'_ZE-2S=tmnHpps(e1s6Nd?4Y?F*LB.``.tr.]6)&((4DiM]CPheL/!T%4ChB:=^P!U2OKM;U9'qZ0JnL'A5@B-b5La)i8&/;W&]%6]_?[.2[XN(e?q?Uqf5&3[%LiM.GmD3`oXDF2cYDA<KqSM<%2QOWU8BUD642$/UBL-md%T,Yq*N0o`9787m'TOZ\N?WCf48"kHl?=3HG-EJ<W1YIHo@70fVTFPUp5#2UJFM3bpPl_`Irr(TpYX7um;nAk]e4;^=)397mUo"ZI\L6)W]GqaoaB"=].h*3fB6S<Qkn:kFiDO!:=2]Urh=O!3KX_(8M;`,e\0ZO&ns0n?-i?&!qHu'&Ant1=8Y@4)oZ0^6$PVZ,mjU=7;RH3HpN6OF;&,s`\')=Tr,jn[hH$PWZ']&&*JZ"Id6"s\$)cOokN0Y[7pEIa7rV];OQ@Xko*4K&6!aL$]E)P&uk5>ICe+P\fbE\$-`Lj2A4R;a,%"6Q'[,=N"PmhNKh5"%`-%e%)7hc@T$9Y%j#Z4t@"eCGNK.,qO<*dV-W@LPHnKcB[;u`"&<p_<@+-As/7+,D<P0"?L$Teq0Jc1D2^XO$__lAT*rd<%lF"`deo4V5D4ZR#SF0"uPXgjVClW.953,O.Gb32jL'o`a8TrD/$SBkP$'b0>REfsWu[ispU0E_VJ(k<bh(r?7]_8?h=?jIg.0Ef:*7:Y"[cf3jY9,X^Bo]hiJV%N]QN)eA3Ya?1X=?Nnqq0L72MjPG76G=N4%ZAE:1N4f1bHXj+_W2c*1R9E21.=D>f=NJ7#[13\"4PfBZA:7CneOe.;p3:u(BobEGYETH0c>13"ZUD)d"T+!3S[3NieeIAc/Q=np9!sQWX=^k<a@Z'$6-hRUpQTITFV6!i1U9@:]_.R(kNA;-p]5F^d&2eTi;gYAElcJ='UQ&^!sf-JlOmilp)hYs,aTh8Ro%/n&!qF2G5,;cV&+0%BQR3-9#Cr4GcHDUF8J;XL6?Gp(Mr8C;m$=E4+\_2b:?NP;c%[ihO.PWXCD^o@H^a_Kh]BPZI#XhVdo/%Y$0_5B-CM!W7Mh*t7*=4T8^oJ'F]VkB]A-p]fFXDjXbA6&HFF]RbqUKf;iUigD_Vo@h;*@Y6TjLNC,Q)fc.KJP1i,%XO9R`Y4RoQ7'g1Kfp%4$Y>6/RB#V)$0u8M6Q$&QMkl0.AU]$$V$Q\o[W5&k"-ART@%mYA/JboWpNTQDBZ.HFZGfg3P^:;-&I0a91dY;eh:*rk#h,!m9"L"80S:\@=Fq\IJ]AB3@0m@.TG't+YQUM!Wp:BTFX<Y15/bQLl<dH*WZ=P%+Hjfs8D:,G0j0*P@J<@8&dM##;Hq?IX"'FWO'!Z/,#Q?.b0U3*Xo#oloV,Z3m8.&k\7,qGYNTL,;RZ?KF--5bbO,4M;mpX_-RY`jI"OG(!.k:q$ighY!+>kXhuO*N!!Eft(]n*OCsffQ`s-UHZ:1sg(3>SC`=R)=AW%c59A(L2\,HYCRF3VFYdCDGnjaNl_+<+NHnA3r(B!i<8IO#!MD8ld<hEk3qu^gNBE"J:M//YlSkHeSDDbr!.AN7Z`@EBHC`.iP;?Zi6<^%#c1\Ge$ei@@=<]=7@_OUNlo(gISfQs3(ERs".D5CueWqh9IM^SI'eO#ia(FWtFIFUYfEAqU^>I?^*i"6,[L]WVc(d\oR6pW2p^`WtF&bT,2i2OU^/pialH0H:,,mQ!T8L-MeM;<u`[8%O5-$U5L+rUO[O^r^A/L>p9(!HONb>m_3WttPF=;a7^A$'gQq:VmGB[Q'F;RAE!Ip03=pV5n+^\FK!fkNpml25[.XftPJ-b5La)fdtE5B-+E!Vh4u*t5pq4T&RmIc0/i6h"km/#L[ujtEiT9k^r/;bu]mmTQ_HME7dQ805!=EC(`AcRZ0.6aKh0IpVXTG:;]WJh:V`.H5&:(nH:W`r%qfVB9K883p%i[8&F%R&s,L4-WU(Y@rA%>>>C8.*uUuVMBgc4C7=V1QGZjF?qNC"Z\/7>f7g<<EtXjX]9`ZC!`TkH2O\FgKK;f?[>UR9lH*t""!G5JfuOnLCt"]#n3&k'1uZ*"J&A8W`AQ<@2>2885d+Q*tuGaSO@K@Ph:IV>3fEJ>(Us,mn&up%@Z.m[Zp_*<@j=QOiX-4i`bN&d/n*co;C^'T;5G+j\JdS\6o\JWjpJ*22Y28"YD&X]Zjfm2%&YdE`-);2qW`&*B;ij!:IY]%L-kW*d9;k47Kb4+l'J@'Rd%[ggCLnUZg4Vh!daI'I.DpCD=i*YXWWL(AJCjY1Q(Q6BU,;$ROt.YiSh;Dk/)/@+sSUZTjT:LY9jcfn,#qSQ27973*sa.&.nldA/J)bR[LV'S3tsP`I95iUL)aQ#YSgTo3gQ.Cs5EiedkPJ`<u3<%,J9/nc]m4FgG`D2#h00KmO[Ut\E?1KX^>,oFK3GV$ZBQG?l73jAel9@/NlV[<T'*N!`-LEs']rA!Ugg.<P#6AZ_=UpWr/UEt.$G+Y!M?-o)o[\]4lW+)1mLdZD4(=tT5N##N2SO9O*%OD:99/ht7`<BVq!lY=Md)s9Sq1=nD)XcakgWG1l2`W=hiZ!9]!tQC@?iYH0J-Q1l!tRL2!ZlUE_%?+iQ&34t4uW1f<[Km#[.o5R-:[bsWD(61G>lc,F`QH.g,\bY(gh1MG/UE3+&j6=FF3@\_*DQU/oEo(a?*[Hl8L>-'@=8a9gIaup/?smmAHCEUX(/tg*h5W'X0?Da/1UX/OM3qMP0jGiluu"EP2Z,NE[rUiGITa0V9j/fXegQESB:3B"9U8Y5!'lM.ce$0VK#GC(NMjXtZQO\=9kj/52-0n:6*65_0.S$ip\DTV)rp?iUA$J>rtj13FmU.uqOS?0YeF]rIVk];r#X&P;XJW+64kKmec3^i%*4>\]2-?<+tMgJq;PM8acW<.8l->3Ao_ZWD-TU=ZHU0QGhGX>&%@5>rE[b/=P`cVtrh?K\M]b(T@I3Q\D!gQ:#Ir.2a-%,_X9ra5_Ui:.%>p]HRA(rBXd1(i]@4o/&Y/h.OJHDX`"K.@U9;.m$4aTLZD:<:=.a35Uu9C`WujC-a)pXqo_Iq%?aCE!LAH)Z^[fpks3W5rk+=H7_PesfS^R.s\rq8t,,>N>sK>3<klbiY-0nB19qqnq^77)?a0;kCq<a&ALlCr9gDP&/#NDieMI2t7*o$8`r/Fkn;^C]r4Nge,/;6ne]hn5+][."R-d$pb1.Pb8[^@%[Xn:o]]g13M\q9O*B\eYmtCO]1WmOoqDrr^5+3^%7@4GSg&p)?Mu3^SXk4I#Cp'/<_$8aI^?0;SD[a"kHkdcfXld:Rl72p*WTn>VQFS2I*<DCr8a\K;8ZSroUDRCkM=<3@V)i)iVTX%ik.J!.!La#6W$LO$"7G*dHb^&Fu:CL<c&J2Ah'W)g_1a(kZ?<L)<;"2U&f$,+O]iZ46>dNbdt(X[1Nbpnr;D@@_iHJRl[2KtBo7bkrJcI[utm6_Y6#om<(OS(gDWhVC*,o3Ulo3q#r'%8joO"!3qB"18QRBISON,E+S]6-&X>VDN1qd"SsEi@Riu:GuVHra`o\qroBZE3AtWabFI,51uS>RdpeJk:YG\Xgjk-l:a*t#4R.p+[CS`'FY!L%%s7,:ga8,SUd`(%5N(f2,#!HhpJBPH%T&_,hbt4`J[9epXg`an1O&p1^%tHIQsU9q"gkf=E^1nMEe@Jn$0u1c<0DFC4>k+:,_`j'djq=?M0h)3,N>MI@P*JT_k-^6HeWkFd$T[:+%F"Q#msc3X7lgn:Lc:JV,$Q^^iR*?jM5>i<Ma>CZZPte?c9q)U_'WTi]Ri8m62:_(+aJ'dQZ^r"\91FZ<\t&+6Z.;hqnL*ThcqRlb00)7T6j1(JU#F#3@sr&'p*:m'QLXrR+&XLHtQ/FfhjmZgY2ZcGqgW9%R:Mh5j*b-;G;lRb&0ggZt8Eq(U$aj2(K_<C]-OB85DIKfOAUd9I4fSEnbFn7+S)o)$@[$oho%0fD^OT\$B!fnTD64t+\5pqi2+:1)k<<!;'VQThl9K\,\6q7-u:Wud"M0AJkE?CA/]cbE0]F-esg+6s"+-9?(r-b!5@bGVT.ZVGV]b_qs@'+S>Zokr6rsJ>FSbQ9J=):0O"aS'&jB%EbAIJ'M`Kn"/lfM91cJ.EUZq>8@"ck`a\:Xh;J\rK:i!qm;?jLu7E<ek@C]4[HF-W@:CdELRfrM$i(?APY6YlcR'?Crn13(/H8nF`T/]7it.$]WJfg<ul12\P[bHXeT^b^DRf@)sHh'Sp;mR4/NN'o5eXXN+m;38+T1728-Vmi-Y,<=&7j%VHUeU`PY*4K&6_HV<nDc2s9"J_0t`"cR>_SeC\"fWV$!a'U$'IIVre!&QZ\r?hH""!G5JfuOnLCt"]#n3&k'1uZ*"J&Ah$PP:<-#kFf`*$C2?ZNl\SOC*gW;$lpok&qh$/UBL-RDD%,bn"L1#]15=E`G[MC5Z2De;NU=DOHlXj@!bKo'SpikiVK?]`.C'jm'6`(0WT'G+I9k-(8cKQB(4.BVSKI),mq*:R>9Gi4)W"2G!L4;\,@Gi6CLn="KVc?2</pk%!AHM+Z?K%)*$p]B"mJo6a>O&%qi*V,@+p6XN2CsB7R]MJENd!MZuTJ-s!pbd.cmKWYA/Z4%"I1I#J_is!&E1Yi3RIfJtadb`3S)G>ZDMdr*!Q.[So`e%K8fAONjqMeh],BTKW%]sj-CHnK<^>[\$XJ#3FL.OL0S-A'$PTH*D/PXI'Bb6;=."6`mgBg*TXb7=o],^e;Hn-L6<\LI-:e5`5f"#)^]Opu!!NR'cj;*SJ:^N]eV+<t\rsB78)f1SouD1CjRsr82^6@]O/\n>bV34PR:5e49%U?f8MV+:;Q_tRr<^H2=EN;-RR]`fprOChSQG4)?H%VT?E`A*7+84%_F10XF(+'\mUlk;/Z83lD.1:B*M8Qs;OA;A3X7lgn:Lc:JV,$Q^^iR*?jM5>i<Ma>CDJ86hQrEa(=nD\7'E2]<T2lQKN6N+QjC;#jU$,Z+-Sn0_^0M?f-Na,%rZHCCc^UBEkEC_,Qg`s5mcPmmoILq:IM\jV1;"`aT6J3a`<0"ng.qrCbW;f%!mgcl1UG`lgVF@XcUOS(:kpgG`$N>QoL'[B8)0mdNF7#D^#Wg6"n3?lFJQ@R.qsT[FOmRBeW'ZO!GQ/&pP\<&<agO#s+1O#"d0uUq/6';ccl+i^'*dV>ckTS_X3si]e^AI4o`MOs!4e0L<q.P;Z&P1oH7K.HMNHre'3!/@p6_Fc<D\/?m]/G?UkVGN-KXV)r[*ief<Y@H*.r87CMQCdBNV/T:74D.1;-)kYV\kmb)ZE<ctt0Ru6(\:Xh;J]Ac>i=8!<?jLu$_F3Q:5<%5H'IJ/![+KsE-AL.S'deP#H[3IDasX!3fKunsOhW%;/mHE-<lQ_fGWF>H!]\P^H9M3?fkl,YiJtlRmo"sDibU@R]TVe2B@16D[`iH[@!4![3/>PcnYH_S(!sJ065SLq;g=MC6mK@8'IL!HJeTQGM(V=&Tb5)?laAKU!goLB<`5;%$"*s0i1U9@:]_.R(kNA;-p]5F^d&2eTi;gTAEleL<a:I0]$qgc^6@;p:`P9:]A]TH<q=.A$0I#rHW%.k5uYAIQ861jD`]@b`1l#U;THl$a9$.Zo;DE;T=?Rpm8$uS\DdloR(2,`;OI5-?]YU]bME)=>F;Y_`[A/oI"O(si.1tO$igeXn6c6@i.2,#^]P*0(]n$M0[[GV`s,n4_F1T!(130?`"69(Ko*%tI[Bl?:+hbq5IlL;EkdGo9WbnEj1[/OPP5tbl4Pn%m[VbIr8CdM,L_uD-bSa=-4J;hFr@%/m4uV+Do*&YC5HgC1$Y!#7*=L]()U81@'gV6GIte_@pMD+-48rm_/+[\DY0^EqgQH_Wm\i@oeh(J9q8W#fi]auS1=MGC#V^6<LT"^buG%<G$g]"<npDQop-q$"*dMU&>m6Q$AL5<##im*.57-@:/!g9-@"f02pAu]\RG?oDCQIY7YB\l,h`,KFgRkK/]#'')po5LP9c]WD)'eGW`XHA?&D:;37f)Ynrkl\3lbE!*D<CGSW5#HM6loReVR<op->TPI*Mh2oqC>grjo((35:Z@ge,-eq40kq3!@(u!l6#k"qV%]JM;aBn-F[j"Lb?ETkD9!4`"3MM,$34X3;a;M(lTm,n^Kb:7MoPH1#,QF,N?.)/`)PhdR-Cj%?iCS2,SJ<cZ@TQ/:=[:mRm2l&l.@M"UIpLaBbMKt];LEY_@UA';ue(BrXZP/CQcT'PbMC#!0k$ZtVactS'*`<`%B'Go7b$P_Jc*OGfd*l=rCVEeQWR%BOCdi6fQJ-e?*?jKHa_$!,5!Wse5";;V+5pr%k$5>UFQmcPoP!h$QIQ,ur9d71\8Tq:1*N^_V9COS#5A@IR6$'Zj(/quJMIj9KV>([[F1p0J=^\@S*jqScPgh+a4A'?&(S!d,'Gm9*CD<E%$sJ9s31Ra$C)"tPjJ9.TDf>mk4`Jc#!U,)e*Xk:E4S3"eHJkJ%6dTW#./MNk\\T/j7a\35`>Q$P0u=g47Y.'1CD8.d@@=#Gc4F3M@EEJ8QSXl5/)cd-bPWem8M&>gH9DRF3P&KK3T>ltmnAO>i`f:(/#+5"dC_0AbYKm\SI%=+iN_fkW<3e;3,Z"J7C__9_J,Ft4MmYS.5"/DQ79P'1h[cd4GHkf9prl<0KmO[Ut\EK1M?iN-5]&_GVm5JR_YR&3me'7:!e`oV_SEO*G15_M^2McrC[K"[A1f,7$?Bh;F`6pck<u!4&AP81h_IWgLC.`<O(oa\J/[#ENZbg,R^]]cDC55Q]at[V+XCVids%$V;d(aBVj^PX?e?K%?L,49r5^PS=GgEnI=(-Ym1bc0Ru<*fRj4kJ]Af?@1PKo?jM,H8k%WP*uh:I.i"V$>-("?'dKfR<%9f^iGs;%UM<#fhrD!!QC#3Y*!a5q'Io3&btc)?SKd%%cRI2`?_QR,0RX)2Ukk5lM(lKB/Q]Efj]ZRi\<c1ghIFN<PAe05,*rtZfIR/*OH4NWbG74'VL&,*qFWH$fgW6&IM9KqF,>#4=o*;5ij?6lb&UA=[-?ag&l7e@8O=IK'd%+d>sUg2:`jE#=cU;si1L2NciF@lk_BWrFJ&k"T[862kg\,fSu7a9AImaQ/U^MUB609k1m%[2#j`T\e2mlofSb'!%_OUp#:F5j+f93[^KD\+#tjP4,h4s[d^)g:XLk:mfj2,9d-3/fBK0dV<bFC-B+',mB)%llR4:P@PMB_JA$DQCkI:uq)=f$\19_mR?BB^A)>&Lh*6=cpADf]Wr?,lo7ThW^=Ou*)o-<U'Ro+@oR9G:Nfo4?-lDu@L\ejJM1-_u:]P6fQ,!S"%q>;VA\-^3&)c753.3hJ/9[^?4!1:u)IcnN-p7P[H(6iUJD;^:#jCB&%Huj<48_IRZ8Kh8tFmmGJ>>M,B]0I>c>NDMZG`#[&2J@f2\nZ2t\kCl;HWG@4n"7WGJ(YMF9MCUjdUjD)h%_a(0E_9@!J_QV`saA.TEd9GR"6=&e-,oFVij5TfAP..p+:RAj>QgDa!_#d"Uao4IlR.rT"Q=bAp'G^.Q54UlfpG'A+r6F4bTVWB0RBCZ-N0er9Pe9%(PjAXp&&]lV\)"=Os;]nB#6I1A2.nEgKK<^q()LP;[-&=a0'2M_=3^(KbcF0=nrm$i86S%UIGBY4f#\IEV09=OqWHaA+n#AR0M>**LiIjhL&WOjD3shF$UL=[+Um=Orgkf=nkukNjMRPB*Pu-$W1`dYIB63FgHR(:h#i,1h-f^D2sFd4FVZk2Zr6<5iIidot#AI]I?!R<4M2<,_)X6Y20\\<?6TD8JKL>1ZP*qpu4fjS$?$@@%u3GuX@$9k*!J,rs"_\Bd]F;Ug4a%J6D"*,;,g25$n!*n5_7#'s*E-h2JR8qrP#K<q3&\"lKWgPq8"UBp3(.+DJkiRj'7p5>0Z_Cc^%Cl%o6eaLAq%Y>>j#YF\)I.W!gFM=t4-_A0mqb'`DK`/m<0)>@%V-VOBT3U(rXkn"@GM2'BXV:4bBbSORG)%`Tpjuh"J]/GtiX6a?TH@P!n-/dcC2`Uo[3WfF=P@nMa%ee"V-Q$)]NX#*I$FF-*q+GGOP)AGP)f2r+6USaTkg:_,3D,"32S@h,s6>d1QaY/"f:U2VqI,[,TW)[jkc_D9:2T5jld(jRh(Qa*E.Hd?*I%Fh4pqJJg0,YIuqGj&f!B0Z3[(i=DmLhk#1OTZa2Ujm5Q"$P-[)0N4nPc)LL(aWpF$cjehYFV:08I/T%6J*^qs@>OKZ-nq^76)(f"@[eG<>fUIq]]id`JncECh9uh%KZ$0BQ]uREWfj"G,T',]<VqKcCfL"gD75`bVGQ#?EXR*pRP!s57QZX*ko<GPZMeL&7"`&&5ZWullEAmNf\5r=cqs/WYkqj?+9:P.V7o<"Sia%&<&1W$HZt*%ghY`L6[Po9IHcu.VM\.\91A4JjfXn5KZ$/2pV7/D@?g%#RVqK^,g-jOUMJBT/gm.5k&W$i7/Qq__hHAl=5.:11*3XC3b1M%D:h+G!D7n#0OP\iAJ"=n=SRuAMBbOeH.&tBq]IV_ufC92<9,=r&SWh'oHu//o+rW0`(U)t3j&HLG?KE_FAadk5$:c:mZM)QXYI&WjeRU>io`kkI]Y`'Z7;[ChY43t`)geoI7YKU:X'BU?HfrAfX*L])<PH5nkEerMZ+%)sY'Ul5A1ug4#7G[e_U4N80C55d?KG[4mj&)A(U%l4<p^?cNE9Phj&Nh.cKCNhZa%!HM6;1>eSK.XnOc9H.OL$Sq;?u,RW.A`Pm4:`R=0@cYprF*<e[N5<VbK4QX;emf%,[eQ$/4_RU_Tj<AYci#*)Zb5]s_Y1UG7".V;`OYpi+DNr'\86R"68PaGU9`7.?-ACcG1M-6,@,.3lW;FXm/r$SpB!Js4I:h"T:Oq9fX;s9M!oucVfYfQ1J!n?S\R*e[+1Ft_KfhAVpL8N,[F^K#IX^>\ONS-;J?knbo*/c'd=Y-E'm.*<5r?]]<Q]Yq>Y`K:7GdE47#chBRZXsls@VN$j%eEDmoug%<2*6VbXFS:/R*AloV-'-kaHkKO_JH#P3%X+n1>XRV/OF>W9ZCnG>:cnAfm*QYX^>\ONS-;J?kon*)mbrQYnS[o$g//7?C6_R$\sGc5fT9^ZpcqaR8'c@,[t%1/X>"7!'75hB"EuT38S$XYW,dlM0YejA<>=Ul6UVe14.T6L($AmSiNSQeKH[$ON-@>B;c;SGlTn-?Y6m/ff7hr'p,r[ON%E^Uq$tLKn5(d0?clqL;Q?P+QL]jg*2K272s[BKCKB#+Y=3iVtJ5,[l&NpO<t<*$oXn9%qDRKBn_A">qaDk.Ybi-^*)I\,2+6ZLIE01R#8.JLU9/DS^oGMh8X7NDm0RNZltFn(e]!B.st%WH=cfG+UtE'RQZLu_1a^XA0c"MU^<l<Z_u:KAZ"4LNT1IK!K/k30e6b5%V^W_M-[<4gI*k?cnq=+&YbY(_\j+DQKiFTDm!%8AZ"1M4E3=o"Y@6(k+`g#7<&tIArTp$A0OP9/E\"@Su%'!$Gf8oh=;[$M4UEZoSb&-=/%#t0@Z'T%.B,HC^IGrZXnGb"XF^D6](%F8\uBK9js8qf.4084X79@G>PX;Ns!a(k!:O^N7gnNG_W*<Cn/0]oLt$ObXMg7YR3oHH:AOp1R:pUG0.S'YNQj17XBg,6LGuVbp(jc4G^u$RSEF5V7ee!b[(j,VSf]O#I0I-YdbOVR@^Yt/$fVY'Y@\=NV!X7L"nu6Rmj\QGS#eTR*G8^V6r&tB.jNRdpX-#OT@\J!Z#EY2UaIJ6=k=KP[`5PZ]Uj<Y`LrfGdE47#S/,cM4ThtoSfWC1)jjZ#X-XF)7,G+5HFo%-YkWf1R++]ZC8WY`NE9ScPk5n4/gggLG[sU,Xra$R%EgVeKGB70*j_i@2ZD6!C*Xe&pG;CR%BEsf-.7M9!R]9fgsG.=NDLn]NIX,KEnbq6Q4E0StS3@iTp`AB0%SZp<4[S'Ta/J87Qtc;B=0mUD1=HR#U_HLP=ML`g]E(7<fB%2P`&jA#TrP3.!sTR1@E-N=>Sj'sM@=)UgL.lB#$`V:bI`lq'P_ncq%!&j(^RBhZiDg2':nG#cdn&:14k11ha5ITQb)g5s>HN28S2'h0Wq^%-"Rd<n4.GXbA_@[7I99[?h@_\pa)&:13@Z6i?ec9q\k/tD`N`gfo]7"Q;sZ5`]`D:9\j~>endstream
 endobj
 xref
-0 118
+0 122
 0000000000 65535 f 
 0000000073 00000 n 
 0000000117 00000 n 
@@ -781,95 +802,99 @@ xref
 0000004738 00000 n 
 0000004875 00000 n 
 0000005012 00000 n 
-0000005149 00000 n 
-0000005286 00000 n 
-0000005424 00000 n 
-0000005562 00000 n 
-0000005700 00000 n 
-0000005838 00000 n 
-0000005976 00000 n 
-0000006114 00000 n 
-0000006252 00000 n 
-0000006390 00000 n 
-0000006528 00000 n 
-0000006666 00000 n 
-0000006802 00000 n 
-0000006938 00000 n 
-0000007074 00000 n 
-0000007210 00000 n 
-0000007346 00000 n 
-0000007482 00000 n 
-0000008507 00000 n 
-0000009300 00000 n 
-0000039220 00000 n 
-0000039460 00000 n 
-0000040642 00000 n 
-0000040713 00000 n 
-0000041010 00000 n 
-0000041106 00000 n 
-0000041202 00000 n 
-0000041302 00000 n 
-0000041398 00000 n 
-0000041498 00000 n 
-0000041594 00000 n 
-0000041694 00000 n 
-0000041790 00000 n 
-0000041890 00000 n 
-0000041986 00000 n 
-0000042086 00000 n 
-0000042182 00000 n 
-0000042282 00000 n 
-0000042378 00000 n 
-0000042478 00000 n 
-0000042574 00000 n 
-0000042674 00000 n 
-0000042770 00000 n 
-0000042870 00000 n 
-0000042966 00000 n 
-0000043066 00000 n 
-0000043162 00000 n 
-0000043262 00000 n 
-0000043358 00000 n 
-0000043458 00000 n 
-0000043554 00000 n 
-0000043654 00000 n 
-0000043750 00000 n 
-0000043850 00000 n 
-0000043946 00000 n 
-0000044046 00000 n 
-0000044142 00000 n 
-0000044242 00000 n 
-0000044338 00000 n 
-0000044438 00000 n 
-0000044534 00000 n 
-0000044634 00000 n 
-0000044731 00000 n 
-0000044832 00000 n 
-0000044929 00000 n 
-0000045030 00000 n 
-0000045127 00000 n 
-0000045228 00000 n 
-0000045325 00000 n 
-0000045426 00000 n 
-0000045523 00000 n 
-0000045624 00000 n 
-0000045721 00000 n 
-0000045822 00000 n 
-0000045919 00000 n 
-0000046020 00000 n 
-0000046117 00000 n 
-0000046218 00000 n 
-0000046280 00000 n 
+0000005150 00000 n 
+0000005288 00000 n 
+0000005426 00000 n 
+0000005564 00000 n 
+0000005702 00000 n 
+0000005840 00000 n 
+0000005978 00000 n 
+0000006116 00000 n 
+0000006254 00000 n 
+0000006392 00000 n 
+0000006530 00000 n 
+0000006668 00000 n 
+0000006806 00000 n 
+0000006944 00000 n 
+0000007080 00000 n 
+0000007216 00000 n 
+0000007352 00000 n 
+0000007488 00000 n 
+0000007624 00000 n 
+0000007760 00000 n 
+0000008814 00000 n 
+0000009607 00000 n 
+0000039527 00000 n 
+0000039767 00000 n 
+0000040949 00000 n 
+0000041020 00000 n 
+0000041317 00000 n 
+0000041413 00000 n 
+0000041513 00000 n 
+0000041609 00000 n 
+0000041705 00000 n 
+0000041805 00000 n 
+0000041901 00000 n 
+0000042001 00000 n 
+0000042097 00000 n 
+0000042197 00000 n 
+0000042293 00000 n 
+0000042393 00000 n 
+0000042489 00000 n 
+0000042589 00000 n 
+0000042685 00000 n 
+0000042785 00000 n 
+0000042881 00000 n 
+0000042981 00000 n 
+0000043077 00000 n 
+0000043177 00000 n 
+0000043273 00000 n 
+0000043373 00000 n 
+0000043469 00000 n 
+0000043569 00000 n 
+0000043665 00000 n 
+0000043765 00000 n 
+0000043861 00000 n 
+0000043961 00000 n 
+0000044057 00000 n 
+0000044157 00000 n 
+0000044253 00000 n 
+0000044353 00000 n 
+0000044449 00000 n 
+0000044549 00000 n 
+0000044645 00000 n 
+0000044745 00000 n 
+0000044842 00000 n 
+0000044943 00000 n 
+0000045040 00000 n 
+0000045141 00000 n 
+0000045238 00000 n 
+0000045339 00000 n 
+0000045436 00000 n 
+0000045537 00000 n 
+0000045634 00000 n 
+0000045735 00000 n 
+0000045832 00000 n 
+0000045933 00000 n 
+0000046030 00000 n 
+0000046131 00000 n 
+0000046228 00000 n 
+0000046329 00000 n 
+0000046426 00000 n 
+0000046527 00000 n 
+0000046624 00000 n 
+0000046725 00000 n 
+0000046787 00000 n 
 trailer
 <<
 /ID 
-[<cf9a1f82dd22c2019b92af73c7ac69fc><cf9a1f82dd22c2019b92af73c7ac69fc>]
+[<b3c4067b2215be19a090180c345708a7><b3c4067b2215be19a090180c345708a7>]
 % ReportLab generated PDF document -- digest (http://www.reportlab.com)
 
-/Info 62 0 R
-/Root 61 0 R
-/Size 118
+/Info 64 0 R
+/Root 63 0 R
+/Size 122
 >>
 startxref
-59700
+60458
 %%EOF

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -272,29 +272,37 @@ def draw_resistor_colorcode(c, value, color1, color2, x, y, width, height, num_c
     width_without_corner = width - 2*border - 2*corner
     stripe_width = width_without_corner/10
 
-    for i in range(num_codes):
+    if value.ohms_val == 0:
+        draw_resistor_stripe(c,
+                        x + border + corner + stripe_width / 2 + 2 * stripe_width * 2,
+                        y + border,
+                        stripe_width,
+                        height - 2 * border,
+                        0)
+    else:
+        for i in range(num_codes):
 
-        if i == num_codes - 1:
-            stripe_value = value.ohms_exp + 2 - num_codes
-        else:
-            stripe_value = value.ohms_val
-            for _ in range(2-i):
-                stripe_value //= 10
-            stripe_value %= 10
+            if i == num_codes - 1:
+                stripe_value = value.ohms_exp + 2 - num_codes
+            else:
+                stripe_value = value.ohms_val
+                for _ in range(2-i):
+                    stripe_value //= 10
+                stripe_value %= 10
+
+            draw_resistor_stripe(c,
+                                x + border + corner + stripe_width / 2 + 2 * stripe_width * i,
+                                y + border,
+                                stripe_width,
+                                height - 2 * border,
+                                stripe_value)
 
         draw_resistor_stripe(c,
-                             x + border + corner + stripe_width / 2 + 2 * stripe_width * i,
-                             y + border,
-                             stripe_width,
-                             height - 2 * border,
-                             stripe_value)
-
-    draw_resistor_stripe(c,
-                         x + width - border - corner - stripe_width * 1.5,
-                         y + border,
-                         stripe_width,
-                         height - 2 * border,
-                         -3)
+                            x + width - border - corner - stripe_width * 1.5,
+                            y + border,
+                            stripe_width,
+                            height - 2 * border,
+                            -3)
 
     c.setFillColor(black)
     c.setStrokeColor(black, 1)
@@ -447,14 +455,14 @@ def draw_resistor_sticker(c, layout, row, column, ohms, draw_center_line=True):
                             rect.left + rect.width/2,
                             rect.bottom + rect.height/4 - rect.height/45,
                             rect.width/4, rect.height/4,
-                            3)
+                            (1 if resistor_value.ohms_val == 0 else 3))
 
     draw_resistor_colorcode(c, resistor_value,
                             toColor("hsl(197, 59%, 100%)"), toColor("hsl(197, 59%, 73%)"),
                             rect.left + rect.width * 0.75,
                             rect.bottom + rect.height/4 - rect.height/45,
                             rect.width/4, rect.height/4,
-                            4)
+                            (1 if resistor_value.ohms_val == 0 else 4))
 
     c.setFont('Arial Bold', smd_font_size * 1.35)
     c.drawString(rect.left + rect.width/2 + rect.width/32, rect.bottom +

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -467,6 +467,9 @@ def draw_resistor_sticker(c, layout, row, column, ohms, draw_center_line=True):
 def render_stickers(c, layout: PaperConfig, values, draw_center_line=True):
     for (rowId, row) in enumerate(values):
         for (columnId, value) in enumerate(row):
+            if not value:
+                if value is None:
+                    continue
             draw_resistor_sticker(c, layout, rowId, columnId, value, draw_center_line)
 
 

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -114,8 +114,11 @@ class StickerRect:
 
 class ResistorValue:
     def __init__(self, ohms):
-        # Fixed-point value with 2 decimals precision
-        ohms_exp = math.floor(math.log10(ohms))
+        if ohms == 0:
+            ohms_exp = 0
+        else:
+            # Fixed-point value with 2 decimals precision
+            ohms_exp = math.floor(math.log10(ohms))
         ohms_val = round(ohms / math.pow(10, ohms_exp - 2))
         ohms_exp -= 2
 
@@ -309,7 +312,10 @@ def get_3digit_code(value):
         return digits + multiplier
 
     if value.ohms_exp == 0:
-        return digits[0] + "R" + digits[1]
+        if value.ohms_val == 0:
+            return "R" + digits
+        else:
+            return digits[0] + "R" + digits[1]
 
     if value.ohms_exp == -1:
         return "R" + digits
@@ -333,7 +339,10 @@ def get_4digit_code(value):
         return digits[0] + digits[1] + "R" + digits[2]
 
     if value.ohms_exp == 0:
-        return digits[0] + "R" + digits[1] + digits[2]
+        if value.ohms_val == 0:
+            return "R" + digits
+        else: 
+            return digits[0] + "R" + digits[1] + digits[2]
 
     if value.ohms_exp == -1:
         return "R" + digits
@@ -458,8 +467,6 @@ def draw_resistor_sticker(c, layout, row, column, ohms, draw_center_line=True):
 def render_stickers(c, layout: PaperConfig, values, draw_center_line=True):
     for (rowId, row) in enumerate(values):
         for (columnId, value) in enumerate(row):
-            if not value:
-                continue
             draw_resistor_sticker(c, layout, rowId, columnId, value, draw_center_line)
 
 

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -115,12 +115,13 @@ class StickerRect:
 class ResistorValue:
     def __init__(self, ohms):
         if ohms == 0:
-            ohms_exp = 0
+            ohms_exp = -2
+            ohms_val = 0
         else:
             # Fixed-point value with 2 decimals precision
             ohms_exp = math.floor(math.log10(ohms))
-        ohms_val = round(ohms / math.pow(10, ohms_exp - 2))
-        ohms_exp -= 2
+            ohms_val = round(ohms / math.pow(10, ohms_exp - 2))
+            ohms_exp -= 2
 
         while ohms_val >= 1000:
             ohms_exp += 1

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -322,7 +322,7 @@ def get_3digit_code(value):
 
     if value.ohms_exp == 0:
         if value.ohms_val == 0:
-            return "R" + digits
+            return "000"
         else:
             return digits[0] + "R" + digits[1]
 
@@ -349,7 +349,7 @@ def get_4digit_code(value):
 
     if value.ohms_exp == 0:
         if value.ohms_val == 0:
-            return "R" + digits
+            return "0000"
         else: 
             return digits[0] + "R" + digits[1] + digits[2]
 

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -114,21 +114,20 @@ class StickerRect:
 
 class ResistorValue:
     def __init__(self, ohms):
-        if ohms == 0:
-            ohms_exp = -2
-            ohms_val = 0
-        else:
+        ohms_exp = 0
+        ohms_val = 0
+
+        if ohms != 0:
             # Fixed-point value with 2 decimals precision
             ohms_exp = math.floor(math.log10(ohms))
             ohms_val = round(ohms / math.pow(10, ohms_exp - 2))
-            ohms_exp -= 2
 
-        while ohms_val >= 1000:
-            ohms_exp += 1
-            ohms_val //= 10
+            while ohms_val >= 1000:
+                ohms_exp += 1
+                ohms_val //= 10
 
         self.ohms_val = ohms_val
-        self.ohms_exp = ohms_exp + 2
+        self.ohms_exp = ohms_exp
 
         # print(self.ohms_val, self.ohms_exp, self.format_value(), self.get_value())
 
@@ -274,11 +273,11 @@ def draw_resistor_colorcode(c, value, color1, color2, x, y, width, height, num_c
 
     if value.ohms_val == 0:
         draw_resistor_stripe(c,
-                        x + border + corner + stripe_width / 2 + 2 * stripe_width * 2,
-                        y + border,
-                        stripe_width,
-                        height - 2 * border,
-                        0)
+                             x + border + corner + stripe_width / 2 + 2 * stripe_width * 2,
+                             y + border,
+                             stripe_width,
+                             height - 2 * border,
+                             0)
     else:
         for i in range(num_codes):
 
@@ -291,18 +290,18 @@ def draw_resistor_colorcode(c, value, color1, color2, x, y, width, height, num_c
                 stripe_value %= 10
 
             draw_resistor_stripe(c,
-                                x + border + corner + stripe_width / 2 + 2 * stripe_width * i,
-                                y + border,
-                                stripe_width,
-                                height - 2 * border,
-                                stripe_value)
+                                 x + border + corner + stripe_width / 2 + 2 * stripe_width * i,
+                                 y + border,
+                                 stripe_width,
+                                 height - 2 * border,
+                                 stripe_value)
 
         draw_resistor_stripe(c,
-                            x + width - border - corner - stripe_width * 1.5,
-                            y + border,
-                            stripe_width,
-                            height - 2 * border,
-                            -3)
+                             x + width - border - corner - stripe_width * 1.5,
+                             y + border,
+                             stripe_width,
+                             height - 2 * border,
+                             -3)
 
     c.setFillColor(black)
     c.setStrokeColor(black, 1)
@@ -314,6 +313,9 @@ def get_3digit_code(value):
     if value.ohms_val % 10 != 0:
         return ""
 
+    if value.ohms_val == 0:
+        return "000"
+
     digits = str(value.ohms_val // 10)
 
     if value.ohms_exp > 0:
@@ -321,10 +323,7 @@ def get_3digit_code(value):
         return digits + multiplier
 
     if value.ohms_exp == 0:
-        if value.ohms_val == 0:
-            return "0"
-        else:
-            return digits[0] + "R" + digits[1]
+        return digits[0] + "R" + digits[1]
 
     if value.ohms_exp == -1:
         return "R" + digits
@@ -340,6 +339,9 @@ def get_3digit_code(value):
 def get_4digit_code(value):
     digits = str(value.ohms_val)
 
+    if value.ohms_val == 0:
+        return "0000"
+
     if value.ohms_exp > 1:
         multiplier = str(value.ohms_exp - 2)
         return digits + multiplier
@@ -348,10 +350,7 @@ def get_4digit_code(value):
         return digits[0] + digits[1] + "R" + digits[2]
 
     if value.ohms_exp == 0:
-        if value.ohms_val == 0:
-            return "0000"
-        else: 
-            return digits[0] + "R" + digits[1] + digits[2]
+        return digits[0] + "R" + digits[1] + digits[2]
 
     if value.ohms_exp == -1:
         return "R" + digits
@@ -455,14 +454,14 @@ def draw_resistor_sticker(c, layout, row, column, ohms, draw_center_line=True):
                             rect.left + rect.width/2,
                             rect.bottom + rect.height/4 - rect.height/45,
                             rect.width/4, rect.height/4,
-                            (1 if resistor_value.ohms_val == 0 else 3))
+                            3)
 
     draw_resistor_colorcode(c, resistor_value,
                             toColor("hsl(197, 59%, 100%)"), toColor("hsl(197, 59%, 73%)"),
                             rect.left + rect.width * 0.75,
                             rect.bottom + rect.height/4 - rect.height/45,
                             rect.width/4, rect.height/4,
-                            (1 if resistor_value.ohms_val == 0 else 4))
+                            4)
 
     c.setFont('Arial Bold', smd_font_size * 1.35)
     c.drawString(rect.left + rect.width/2 + rect.width/32, rect.bottom +
@@ -476,9 +475,8 @@ def draw_resistor_sticker(c, layout, row, column, ohms, draw_center_line=True):
 def render_stickers(c, layout: PaperConfig, values, draw_center_line=True):
     for (rowId, row) in enumerate(values):
         for (columnId, value) in enumerate(row):
-            if not value:
-                if value is not 0:
-                    continue
+            if value is None:
+                continue
             draw_resistor_sticker(c, layout, rowId, columnId, value, draw_center_line)
 
 
@@ -511,7 +509,7 @@ def main():
     # Add "None" if no label should get generated at a specific position.
     # ############################################################################
     resistor_values = [
-        [.1,           .02,          .003],
+        [0,            0.02,         .1],
         [1,            12,           13],
         [210,          220,          330],
         [3100,         3200,         3300],

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -322,7 +322,7 @@ def get_3digit_code(value):
 
     if value.ohms_exp == 0:
         if value.ohms_val == 0:
-            return "000"
+            return "0"
         else:
             return digits[0] + "R" + digits[1]
 

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -468,7 +468,7 @@ def render_stickers(c, layout: PaperConfig, values, draw_center_line=True):
     for (rowId, row) in enumerate(values):
         for (columnId, value) in enumerate(row):
             if not value:
-                if value is None:
+                if value is not 0:
                     continue
             draw_resistor_sticker(c, layout, rowId, columnId, value, draw_center_line)
 


### PR DESCRIPTION
There are 0 ohm resistors, however this script currently assumes all resistor values are >=1. If you attempt to generate a 0 ohm resistor it will be skipped. 


```
    resistor_values = [
        [0,         1,          10],
        [100,       1000,       10000],
        [0.1,       0.01,       0.001],
        [200000,    3000000,    40000000],
    ]
 ```

# Before
<img width="1278" alt="Screen Shot 2022-11-05 at 6 32 56 PM" src="https://user-images.githubusercontent.com/242382/200148593-5b57967f-60b6-4126-aa3c-4d7b7de1eebb.png">

# After
<img width="988" alt="Screen Shot 2022-11-05 at 6 30 16 PM" src="https://user-images.githubusercontent.com/242382/200148592-db8f2ac4-05b6-464c-9b81-9fb5f6721412.png">


~Note:  Technically [0 ohm resistors](https://en.wikipedia.org/wiki/Zero-ohm_link) have only 1 band instead of 3. However refactoring this script to allow only single band images may be a much larger refactor, which may or may not be worth the effort for this single obscure resistor value.~
![](https://upload.wikimedia.org/wikipedia/commons/thumb/4/45/0_ohm_axial_resistor.jpg/440px-0_ohm_axial_resistor.jpg)


## Update: 
Now shows single band. 
<img width="268" alt="Screen Shot 2022-11-06 at 12 05 55 AM" src="https://user-images.githubusercontent.com/242382/200156830-d2f0d7d0-3ec1-4049-9633-bfdbe7b09c2f.png">




