### PR TITLE
Rework resistor colors

### DIFF
--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -223,7 +223,7 @@ class ResistorValue:
 def resistor_color_table(num: int) -> HexColor:
     return [
         HexColor("#000000"),
-        HexColor("#964B00"),
+        HexColor("#7C4700"),
         HexColor("#FF0000"),
         HexColor("#FFA500"),
         HexColor("#FFFF00"),

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -223,14 +223,14 @@ class ResistorValue:
 def resistor_color_table(num: int) -> HexColor:
     return [
         HexColor("#000000"),
-        HexColor("#994d00"),
+        HexColor("#964B00"),
         HexColor("#FF0000"),
-        HexColor("#FF9900"),
+        HexColor("#FFA500"),
         HexColor("#FFFF00"),
         HexColor("#00FF00"),
         HexColor("#0000FF"),
-        HexColor("#FF00FF"),
-        HexColor("#CCCCCC"),
+        HexColor("#8F00FF"),
+        HexColor("#808080"),
         HexColor("#FFFFFF"),
     ][num]
 
@@ -266,10 +266,10 @@ def draw_resistor_stripe(c: Canvas, x: float, y: float, width: float, height: fl
 
     elif stripe_value == -1:
         gold_table = [
-            HexColor("#fefefe"),
-            HexColor("#f7febe"),
-            HexColor("#effe41"),
-            HexColor("#c5d24f"),
+            HexColor("#FFED8A"),
+            HexColor("#FFE55C"),
+            HexColor("#FFD700"),
+            HexColor("#D1B000"),
         ]
 
         draw_fancy_resistor_stripe(c, x, y, width, height, gold_table)
@@ -277,10 +277,10 @@ def draw_resistor_stripe(c: Canvas, x: float, y: float, width: float, height: fl
 
     elif stripe_value == -2:
         silver_table = [
-            HexColor("#fefefe"),
-            HexColor("#e0e0e0"),
-            HexColor("#cdcdcd"),
-            HexColor("#b5b5b5"),
+            HexColor("#D0D0D0"),
+            HexColor("#A9A9A9"),
+            HexColor("#929292"),
+            HexColor("#7B7B7B"),
         ]
 
         draw_fancy_resistor_stripe(c, x, y, width, height, silver_table)

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -223,13 +223,13 @@ class ResistorValue:
 def resistor_color_table(num: int) -> HexColor:
     return [
         HexColor("#000000"),
-        HexColor("#633800"),
+        HexColor("#964B00"),
         HexColor("#FF0000"),
         HexColor("#FFA500"),
         HexColor("#FFFF00"),
         HexColor("#00FF00"),
         HexColor("#0000FF"),
-        HexColor("#A32EFF"),
+        HexColor("#C576F6"),
         HexColor("#808080"),
         HexColor("#FFFFFF"),
     ][num]
@@ -255,6 +255,7 @@ def draw_fancy_resistor_stripe(
     c.rect(x, y+height*1/6, width, height/6, fill=1, stroke=0)
     c.setFillColor(color_table[3])
     c.rect(x, y+height*0/6, width, height/6, fill=1, stroke=0)
+
 
 def draw_resistor_stripe_border(c: Canvas, x: float, y: float, width: float, height: float) -> None:
     c.setLineWidth(0.3)

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -229,7 +229,7 @@ def resistor_color_table(num: int) -> HexColor:
         HexColor("#FFFF00"),
         HexColor("#00FF00"),
         HexColor("#0000FF"),
-        HexColor("#C576F6"),
+        HexColor("#C520F6"),
         HexColor("#808080"),
         HexColor("#FFFFFF"),
     ][num]

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -224,7 +224,7 @@ def resistor_color_table(num: int) -> HexColor:
     return [
         HexColor("#000000"),
         HexColor("#964B00"),
-        HexColor("#FF0000"),
+        HexColor("#FF3030"),
         HexColor("#FFA500"),
         HexColor("#FFFF00"),
         HexColor("#00FF00"),

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -229,7 +229,7 @@ def resistor_color_table(num: int) -> HexColor:
         HexColor("#FFFF00"),
         HexColor("#00FF00"),
         HexColor("#0000FF"),
-        HexColor("#8F00FF"),
+        HexColor("#A32EFF"),
         HexColor("#808080"),
         HexColor("#FFFFFF"),
     ][num]
@@ -256,23 +256,30 @@ def draw_fancy_resistor_stripe(
     c.setFillColor(color_table[3])
     c.rect(x, y+height*0/6, width, height/6, fill=1, stroke=0)
 
+def draw_resistor_stripe_border(c: Canvas, x: float, y: float, width: float, height: float) -> None:
+    c.setLineWidth(0.3)
+    c.setFillColor(black, 0.0)
+    c.setStrokeColorRGB(0.5, 0.5, 0.5, 0.5)
+    c.rect(x, y, width, height, fill=0, stroke=1)
+
 
 def draw_resistor_stripe(c: Canvas, x: float, y: float, width: float, height: float, stripe_value: int) -> None:
-
     if 0 <= stripe_value <= 9:
         c.setFillColor(resistor_color_table(stripe_value))
         c.rect(x, y, width, height, fill=1, stroke=0)
+        draw_resistor_stripe_border(c, x, y, width, height)
         return
 
     elif stripe_value == -1:
         gold_table = [
-            HexColor("#FFED8A"),
+            HexColor("#FFF0A0"),
             HexColor("#FFE55C"),
             HexColor("#FFD700"),
             HexColor("#D1B000"),
         ]
 
         draw_fancy_resistor_stripe(c, x, y, width, height, gold_table)
+        draw_resistor_stripe_border(c, x, y, width, height)
         return
 
     elif stripe_value == -2:
@@ -284,6 +291,7 @@ def draw_resistor_stripe(c: Canvas, x: float, y: float, width: float, height: fl
         ]
 
         draw_fancy_resistor_stripe(c, x, y, width, height, silver_table)
+        draw_resistor_stripe_border(c, x, y, width, height)
         return
 
     else:

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -223,7 +223,7 @@ class ResistorValue:
 def resistor_color_table(num: int) -> HexColor:
     return [
         HexColor("#000000"),
-        HexColor("#7C4700"),
+        HexColor("#633800"),
         HexColor("#FF0000"),
         HexColor("#FFA500"),
         HexColor("#FFFF00"),
@@ -259,7 +259,7 @@ def draw_fancy_resistor_stripe(
 def draw_resistor_stripe_border(c: Canvas, x: float, y: float, width: float, height: float) -> None:
     c.setLineWidth(0.3)
     c.setFillColor(black, 0.0)
-    c.setStrokeColorRGB(0.5, 0.5, 0.5, 0.5)
+    c.setStrokeColorRGB(0.2, 0.2, 0.2, 0.5)
     c.rect(x, y, width, height, fill=0, stroke=1)
 
 


### PR DESCRIPTION
Reasons for the rework:
- gold looked like pale green
- violet looked like pink
- orange/red/brown were too close to each other
- gray was too close to the background color

Fixes:
- modified colors, based on suggestions by https://www.canva.com/colors/color-meanings
- added slight borders around the lines to distinguish them better from the background

The new colors can be visualized using the following code:

    import matplotlib.pyplot as plt

    xs = []
    ys = []
    cs = []
    for i in range(10):
        color = resistor_color_table(i)
        (r, g, b) = color.rgb()
        sum = r+g+b
        if sum == 0:
            sum = 3
            r = 1
            g = 1
            b = 1
        r = r/sum
        g = g/sum
        b = b/sum

        x = 0.5 * g + b
        y = g

        xs.append(x)
        ys.append(y)
        cs.append(color.rgba())

    plt.scatter(xs, ys, c=cs)
    plt.show()

Which produces the following image:
    
![NewColors](https://user-images.githubusercontent.com/3129043/223805092-90b898f7-95dc-4ca4-865d-769438d04a27.png)

Whoever still needs the old colors, use this version: https://github.com/Finomnis/ResistorLabels/releases/tag/old_colors