### PR TITLE
Don't generate 3 band resistor when it can't represent the value

### DIFF
--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -347,6 +347,7 @@ def draw_resistor_colorcode(
         num_codes: int,
         tolerance_value: Optional[float],
 ) -> None:
+    # Only display resistors that can accurately represent the given value
     if value.ohms_val % (10 ** (4 - num_codes)):
         return
 

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -347,7 +347,7 @@ def draw_resistor_colorcode(
         num_codes: int,
         tolerance_value: Optional[float],
 ) -> None:
-    if num_codes == 3 and value.ohms_val % 10:
+    if value.ohms_val % (10 ** (4 - num_codes)):
         return
 
     resistance_values: List[int] = []

--- a/LabelGenerator.py
+++ b/LabelGenerator.py
@@ -347,6 +347,8 @@ def draw_resistor_colorcode(
         num_codes: int,
         tolerance_value: Optional[float],
 ) -> None:
+    if num_codes == 3 and value.ohms_val % 10:
+        return
 
     resistance_values: List[int] = []
     for i in range(num_codes-1):


### PR DESCRIPTION
This patch prevents the generation of 3 band resistor images for values it can't accurately represent.